### PR TITLE
Don't let delimiters set in partial affect parent.

### DIFF
--- a/src/mustache.cpp
+++ b/src/mustache.cpp
@@ -310,6 +310,9 @@ QString Renderer::render(const QString& _template, int startPos, int endPos, Con
 			break;
 		case Tag::Partial:
 		{
+			QString tagStartMarker = m_tagStartMarker;
+			QString tagEndMarker = m_tagEndMarker;
+
 			m_partialStack.push(tag.key);
 
 			QString partial = context->partialValue(tag.key);
@@ -317,6 +320,9 @@ QString Renderer::render(const QString& _template, int startPos, int endPos, Con
 			lastTagEnd = tag.end;
 
 			m_partialStack.pop();
+
+			m_tagStartMarker = tagStartMarker;
+			m_tagEndMarker = tagEndMarker;
 		}
 		break;
 		case Tag::SetDelimiter:

--- a/tests/test_mustache.cpp
+++ b/tests/test_mustache.cpp
@@ -425,7 +425,6 @@ void TestMustache::testConformance()
 	QEXPECT_FAIL("delimiters.json - Sections", "TODO", Abort);
 	QEXPECT_FAIL("delimiters.json - Inverted Sections", "TODO", Abort);
 	QEXPECT_FAIL("delimiters.json - Partial Inheritence", "TODO", Abort);
-	QEXPECT_FAIL("delimiters.json - Post-Partial Behavior", "TODO", Abort);
 	QEXPECT_FAIL("delimiters.json - Standalone Tag", "TODO", Abort);
 	QEXPECT_FAIL("delimiters.json - Indented Standalone Tag", "TODO", Abort);
 	QEXPECT_FAIL("delimiters.json - Standalone Line Endings", "TODO", Abort);


### PR DESCRIPTION
This fixes the "Post-Partial Behavior" test in delimiters.json.
