### PR TITLE
Fix falseyness of hashes/maps.

### DIFF
--- a/src/mustache.cpp
+++ b/src/mustache.cpp
@@ -127,6 +127,10 @@ bool QtVariantContext::isFalse(const QString& key) const
 		return !value.toBool();
 	case QVariant::List:
 		return value.toList().isEmpty();
+	case QVariant::Hash:
+		return value.toHash().isEmpty();
+	case QVariant::Map:
+		return value.toMap().isEmpty();
 	default:
 		return value.toString().isEmpty();
 	}

--- a/tests/test_mustache.cpp
+++ b/tests/test_mustache.cpp
@@ -436,7 +436,6 @@ void TestMustache::testConformance()
 	QEXPECT_FAIL("interpolation.json - Dotted Names - Ampersand Interpolation", "TODO", Abort);
 	QEXPECT_FAIL("interpolation.json - Dotted Names - Arbitrary Depth", "TODO", Abort);
 	QEXPECT_FAIL("interpolation.json - Dotted Names - Initial Resolution", "TODO", Abort);
-	QEXPECT_FAIL("inverted.json - Context", "TODO", Abort);
 	QEXPECT_FAIL("inverted.json - Doubled", "TODO", Abort);
 	QEXPECT_FAIL("inverted.json - Dotted Names - Truthy", "TODO", Abort);
 	QEXPECT_FAIL("inverted.json - Standalone Lines", "TODO", Abort);
@@ -448,7 +447,6 @@ void TestMustache::testConformance()
 	QEXPECT_FAIL("partials.json - Standalone Without Previous Line", "TODO", Abort);
 	QEXPECT_FAIL("partials.json - Standalone Without Newline", "TODO", Abort);
 	QEXPECT_FAIL("partials.json - Standalone Indentation", "TODO", Abort);
-	QEXPECT_FAIL("sections.json - Context", "TODO", Abort);
 	QEXPECT_FAIL("sections.json - Deeply Nested Contexts", "TODO", Abort);
 	QEXPECT_FAIL("sections.json - Doubled", "TODO", Abort);
 	QEXPECT_FAIL("sections.json - Implicit Iterator - String", "TODO", Abort);
@@ -471,7 +469,6 @@ void TestMustache::testConformance()
 	QEXPECT_FAIL("~lambdas.json - Section - Expansion", "Expected failure", Abort);
 	QEXPECT_FAIL("~lambdas.json - Section - Alternate Delimiters", "Expected failure", Abort);
 	QEXPECT_FAIL("~lambdas.json - Section - Multiple Calls", "Expected failure", Abort);
-	QEXPECT_FAIL("~lambdas.json - Inverted Section", "Expected failure", Abort);
 
 	QCOMPARE(output, expected);
 }


### PR DESCRIPTION
Hashes and maps are falsey only if they are empty. The current test deemed `QVariantHashes/-Maps` as false if `.toString().isEmpty()`, which is always true on maps/hashes. This patch makes the test use the `QHash::isEmpty()` and `QMap::isEmpty()` instead.

This fixes the "Context" tests in `sections.json` and `inverted.json` (and also by "accident" the "Inverted Section" test in `~lambdas.json`. (I'll fix so that the test doesn't even load cases from `~lambdas.json` in a separate commit.)
