### PR TITLE
Add .travis.yml file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install libqtcore4 qt4-qmake
+ - sudo apt-get install -qq libqtcore4 qt4-qmake
 
 script:
  - qmake && make && ./qt-mustache


### PR DESCRIPTION
Only Qt 4 is available on 12.04 LTS that Travis runs. There are PPAs with Qt 5 but they are not supported anymore. Once Travis is on 14.04 LTS we can start testing on Qt 5 as well.

It's my first .travis.yml so I hope it's correct.
