### PR TITLE
Set delimiters to default before rendering partial.

### DIFF
--- a/src/mustache.cpp
+++ b/src/mustache.cpp
@@ -317,6 +317,9 @@ QString Renderer::render(const QString& _template, int startPos, int endPos, Con
 			QString tagStartMarker = m_tagStartMarker;
 			QString tagEndMarker = m_tagEndMarker;
 
+			m_tagStartMarker = m_defaultTagStartMarker;
+			m_tagEndMarker = m_defaultTagEndMarker;
+
 			m_partialStack.push(tag.key);
 
 			QString partial = context->partialValue(tag.key);


### PR DESCRIPTION
Apparently delimiter settings should not be inherited in partials at all.

No changes in test results, but the "Partial Inheritence" test in `delimiters.json` is now one step closer to passing (only standalone handling preventing it from passing).
