### PR TITLE
Fix handling partials from standalone < tags.

### DIFF
--- a/src/mustache.h
+++ b/src/mustache.h
@@ -257,6 +257,7 @@ private:
 	static void expandTag(Tag& tag, const QString& content);
 
 	QStack<QString> m_partialStack;
+	QString m_indent;
 	QString m_error;
 	int m_errorPos;
 	QString m_errorPartial;
@@ -266,6 +267,8 @@ private:
 
 	QString m_defaultTagStartMarker;
 	QString m_defaultTagEndMarker;
+
+	static const QRegExp LINE_SEP;
 };
 
 /** A convenience function which renders a template using the given data. */

--- a/tests/test_mustache.cpp
+++ b/tests/test_mustache.cpp
@@ -421,9 +421,6 @@ void TestMustache::testConformance()
 	QEXPECT_FAIL("interpolation.json - Dotted Names - Arbitrary Depth", "TODO", Abort);
 	QEXPECT_FAIL("interpolation.json - Dotted Names - Initial Resolution", "TODO", Abort);
 	QEXPECT_FAIL("inverted.json - Dotted Names - Truthy", "TODO", Abort);
-	QEXPECT_FAIL("partials.json - Standalone Without Previous Line", "TODO", Abort);
-	QEXPECT_FAIL("partials.json - Standalone Without Newline", "TODO", Abort);
-	QEXPECT_FAIL("partials.json - Standalone Indentation", "TODO", Abort);
 	QEXPECT_FAIL("sections.json - Implicit Iterator - String", "TODO", Abort);
 	QEXPECT_FAIL("sections.json - Implicit Iterator - Integer", "TODO", Abort);
 	QEXPECT_FAIL("sections.json - Implicit Iterator - Decimal", "TODO", Abort);


### PR DESCRIPTION
If the < tag is standalone, each non-empty line of the partial should be indented before it is rendered. The [spec](https://github.com/mustache/spec/blob/v1.1.2/specs/partials.yml#L12-L14) actually says all lines, not specifically non-empty ones. But the spec tests seems to expect only non-empty ones to be indented, and I've verified that other implementations (e.g. Pystache) do it this way.

3 more test cases now pass. The remaining failures are all related to dotted names and implicit iterators, which are not supported yet.  I have no pressing need for them so I might take a break here :)
