### PR TITLE
Treat zero as falsy

### DIFF
--- a/src/mustache.cpp
+++ b/src/mustache.cpp
@@ -123,6 +123,13 @@ bool QtVariantContext::isFalse(const QString& key) const
 {
 	QVariant value = this->value(key);
 	switch (value.userType()) {
+	case QMetaType::QChar:
+	case QMetaType::Double:
+	case QMetaType::Float:
+	case QMetaType::Int:
+	case QMetaType::UInt:
+	case QMetaType::LongLong:
+	case QMetaType::ULongLong:
 	case QVariant::Bool:
 		return !value.toBool();
 	case QVariant::List:

--- a/tests/test_mustache.cpp
+++ b/tests/test_mustache.cpp
@@ -115,7 +115,7 @@ void TestMustache::testFalsiness()
 	data["bool"] = 0u;
 	context = Mustache::QtVariantContext(data);
 	output = renderer.render(_template, &context);
-	QVERIFY2(output.isEmpty(), "0 evaluated as truthy");
+	QVERIFY2(output.isEmpty(), "0u evaluated as truthy");
 
 	// test falsiness of 0ll
 	data["bool"] = 0ll;

--- a/tests/test_mustache.cpp
+++ b/tests/test_mustache.cpp
@@ -99,6 +99,55 @@ void TestMustache::testSections()
 	QCOMPARE(output, expectedOutput);
 }
 
+void TestMustache::testFalsiness()
+{
+	Mustache::Renderer renderer;
+	QVariantHash data;
+	QString _template = "{{#bool}}This should not be shown{{/bool}}";
+
+	// test falsiness of 0
+	data["bool"] = 0;
+	Mustache::QtVariantContext context = Mustache::QtVariantContext(data);
+	QString output = renderer.render(_template, &context);
+	QVERIFY2(output.isEmpty(), "0 evaluated as truthy");
+
+	// test falsiness of 0u
+	data["bool"] = 0u;
+	context = Mustache::QtVariantContext(data);
+	output = renderer.render(_template, &context);
+	QVERIFY2(output.isEmpty(), "0 evaluated as truthy");
+
+	// test falsiness of 0ll
+	data["bool"] = 0ll;
+	context = Mustache::QtVariantContext(data);
+	output = renderer.render(_template, &context);
+	QVERIFY2(output.isEmpty(), "0ll evaluated as truthy");
+
+	// test falsiness of 0ull
+	data["bool"] = 0ull;
+	context = Mustache::QtVariantContext(data);
+	output = renderer.render(_template, &context);
+	QVERIFY2(output.isEmpty(), "0ull evaluated as truthy");
+
+	// test falsiness of 0.0
+	data["bool"] = 0.0;
+	context = Mustache::QtVariantContext(data);
+	output = renderer.render(_template, &context);
+	QVERIFY2(output.isEmpty(), "0.0 evaluated as truthy");
+
+	// test falsiness of 0.0f
+	data["bool"] = 0.0f;
+	context = Mustache::QtVariantContext(data);
+	output = renderer.render(_template, &context);
+	QVERIFY2(output.isEmpty(), "0.0f evaluated as truthy");
+
+	// test falsiness of '\0'
+	data["bool"] = '\0';
+	context = Mustache::QtVariantContext(data);
+	output = renderer.render(_template, &context);
+	QVERIFY2(output.isEmpty(), "'\0' evaluated as truthy");
+}
+
 void TestMustache::testContextLookup()
 {
 	QVariantHash fileMap;

--- a/tests/test_mustache.h
+++ b/tests/test_mustache.h
@@ -28,6 +28,7 @@ private Q_SLOTS:
 	void testPartialFile();
 	void testPartials();
 	void testSections();
+	void testFalsiness();
 	void testSetDelimiters();
 	void testValues();
 	void testEscaping();


### PR DESCRIPTION
The spec says falsiness should be determined by the host language, so I think this is the right thing to do.