### PR TITLE
Explicitly cast size_t to int to avoid warnings on x64 builds

### DIFF
--- a/src/mustache.cpp
+++ b/src/mustache.cpp
@@ -45,7 +45,7 @@ QString escapeHtml(const QString& input)
 		}
 		if (replacement) {
 			escaped.replace(i, 1, QLatin1String(replacement));
-			i += strlen(replacement);
+			i += (int)strlen(replacement);
 		} else {
 			++i;
 		}


### PR DESCRIPTION
Warning generated by MSVC2016_64bit:

* warning: C4267: '+=': conversion from 'size_t' to 'int', possible loss of data