### PR TITLE
Fix formatting of float values in [0.5, 0.5)

### DIFF
--- a/src/mustache.cpp
+++ b/src/mustache.cpp
@@ -139,9 +139,12 @@ bool QtVariantContext::isFalse(const QString& key) const
 {
 	QVariant value = this->value(key);
 	switch (value.userType()) {
-	case QMetaType::QChar:
 	case QMetaType::Double:
 	case QMetaType::Float:
+		// QVariant::toBool() rounds floats to the nearest int and then compares
+		// against 0, which is not the falsiness behavior we want.
+		return value.toDouble() == 0.;
+	case QMetaType::QChar:
 	case QMetaType::Int:
 	case QMetaType::UInt:
 	case QMetaType::LongLong:
@@ -162,9 +165,6 @@ bool QtVariantContext::isFalse(const QString& key) const
 
 QString QtVariantContext::stringValue(const QString& key) const
 {
-	if (isFalse(key) && value(key).userType() != QVariant::Bool) {
-		return QString();
-	}
 	return value(key).toString();
 }
 

--- a/tests/test_mustache.cpp
+++ b/tests/test_mustache.cpp
@@ -15,6 +15,7 @@
 #include "test_mustache.h"
 
 #include <QDir>
+#include <QList>
 #include <QFile>
 #include <QHash>
 #include <QString>
@@ -52,6 +53,24 @@ void TestMustache::testValues()
 	QString output = renderer.render(_template, &context);
 
 	QCOMPARE(output, expectedOutput);
+}
+
+void TestMustache::testFloatValues()
+{
+  QList<float> values = {-3., -0.5, 0., 0.5, 1., 1.5, 3.};
+
+  for (auto value : values) {
+    QVariantHash map;
+    map["val"] = value;
+    QString _template = "Value: {{val}}";
+    QString expectedOutput = "Value: " + QString::number(value);
+
+    Mustache::Renderer renderer;
+    Mustache::QtVariantContext context(map);
+    QString output = renderer.render(_template, &context);
+
+    QCOMPARE(output, expectedOutput);
+  }
 }
 
 QVariantHash contactInfo(const QString& name, const QString& email)
@@ -135,6 +154,18 @@ void TestMustache::testFalsiness()
 	context = Mustache::QtVariantContext(data);
 	output = renderer.render(_template, &context);
 	QVERIFY2(output.isEmpty(), "0.0 evaluated as truthy");
+
+	// test falsiness of 0.4
+	data["bool"] = 0.4f;
+	context = Mustache::QtVariantContext(data);
+	output = renderer.render(_template, &context);
+	QVERIFY2(!output.isEmpty(), "0.4 evaluated as falsey");
+
+	// test falsiness of 0.5
+	data["bool"] = 0.5f;
+	context = Mustache::QtVariantContext(data);
+	output = renderer.render(_template, &context);
+	QVERIFY2(!output.isEmpty(), "0.5f evaluated as falsey");
 
 	// test falsiness of 0.0f
 	data["bool"] = 0.0f;
@@ -501,4 +532,3 @@ int main(int argc, char** argv)
 	TestMustache testObject;
 	return QTest::qExec(&testObject, argc, argv);
 }
-

--- a/tests/test_mustache.h
+++ b/tests/test_mustache.h
@@ -29,6 +29,7 @@ private Q_SLOTS:
 	void testPartials();
 	void testSections();
 	void testFalsiness();
+	void testFloatValues();
 	void testSetDelimiters();
 	void testValues();
 	void testEscaping();


### PR DESCRIPTION
Fix two issues with handling of float values:

 - Float values in the range [0.5, 0.5) were not displayed in a value context (`{{ val }}`). The logic in `QtVariantContext::stringValue` was just incorrect here as it formatted all falsey non-boolean values as empty strings. I'm unclear why this was done and reverting the behavior does not break any tests.

 - All float values in the range [0.5, 0.5) were considered falsey in a boolean context (eg. section headings) instead of just 0.

For the second item, in Qt 5.15, `QVariant(someFloat).toBool()` does not behave as per the documentation which says:

> Returns true if the variant has userType() QMetaType::Bool, QMetaType::QChar,
> QMetaType::Double, QMetaType::Int, QMetaType::LongLong, QMetaType::UInt,
> or QMetaType::ULongLong and the value is non-zero

What the implementation actually does is convert the value to a number using `qMetaTypeNumber`, which internally rounds the float using `qRound64` and then compares the result against 0.

[1] https://github.com/qt/qtbase/blob/4ee4fc18b4067b90efa46ca9baba74f53b54d9ec/src/corelib/kernel/qvariant.cpp#L786