### PR TITLE
Support Qt 6 in mustache.cpp and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,14 @@ add_library(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
 )
-find_package(Qt5 COMPONENTS Core REQUIRED)
 
-target_link_libraries(${PROJECT_NAME}
-    PRIVATE Qt5::Core)
+find_package(Qt6 COMPONENTS Core REQUIRED)
+if (Qt6_FOUND)
+  target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Core)
+else()
+  find_package(Qt5 COMPONENTS Core REQUIRED)
+  target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Core)
+endif()
 
 #tests related stuff
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
@@ -27,14 +31,25 @@ endif()
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
     SET(TEST_PROPJECT_NAME "${PROJECT_NAME}_tests")
     enable_testing()
-    find_package(Qt5Test REQUIRED)
+
+    if (Qt6_FOUND)
+      find_package(Qt6Test REQUIRED)
+    else()
+      find_package(Qt5Test REQUIRED)
+    endif()
+
     add_executable(${TEST_PROPJECT_NAME}
         tests/test_mustache.cpp
         tests/test_mustache.h
     )
-
     add_test(${TEST_PROPJECT_NAME} ${TEST_PROPJECT_NAME})
-    target_link_libraries(${TEST_PROPJECT_NAME} Qt5::Test ${PROJECT_NAME})
+
+    if (Qt6_FOUND)
+      target_link_libraries(${TEST_PROPJECT_NAME} Qt6::Test ${PROJECT_NAME})
+    else()
+      target_link_libraries(${TEST_PROPJECT_NAME} Qt5::Test ${PROJECT_NAME})
+    endif()
+
     file(GLOB TEST_CONTENTS
         "tests/specs/*.json"
         "tests/partial.mustache"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For further examples, see the tests in `test_mustache.cpp`
  qt-mustache is licensed under the BSD license. 
 
 ### Dependencies
- qt-mustache depends on the QtCore library.  It is compatible with Qt 4 and Qt 5.
+ qt-mustache depends on the QtCore library.  It is compatible with Qt 5 and Qt 6.
  
 ## Usage
 

--- a/src/mustache.cpp
+++ b/src/mustache.cpp
@@ -31,7 +31,7 @@ QString Mustache::renderTemplate(const QString& templateString, const QVariantHa
 QString escapeHtml(const QString& input)
 {
 	QString escaped(input);
-	for (int i=0; i < escaped.count();) {
+	for (int i=0; i < escaped.length();) {
 		const char* replacement = 0;
 		ushort ch = escaped.at(i).unicode();
 		if (ch == '&') {
@@ -102,7 +102,7 @@ QtVariantContext::QtVariantContext(const QVariant& root, PartialResolver* resolv
 
 QVariant variantMapValue(const QVariant& value, const QString& key)
 {
-	if (value.userType() == QVariant::Map) {
+	if (value.userType() == QMetaType::QVariantMap) {
 		return value.toMap().value(key);
 	} else {
 		return value.toHash().value(key);
@@ -149,14 +149,14 @@ bool QtVariantContext::isFalse(const QString& key) const
 	case QMetaType::UInt:
 	case QMetaType::LongLong:
 	case QMetaType::ULongLong:
-	case QVariant::Bool:
+	case QMetaType::Bool:
 		return !value.toBool();
-	case QVariant::List:
-	case QVariant::StringList:
+	case QMetaType::QVariantList:
+	case QMetaType::QStringList:
 		return value.toList().isEmpty();
-	case QVariant::Hash:
+	case QMetaType::QVariantHash:
 		return value.toHash().isEmpty();
-	case QVariant::Map:
+	case QMetaType::QVariantMap:
 		return value.toMap().isEmpty();
 	default:
 		return value.toString().isEmpty();
@@ -275,10 +275,10 @@ QString Renderer::render(const QString& _template, int startPos, int endPos, Con
 	while (m_errorPos == -1) {
 		Tag tag = findTag(_template, lastTagEnd, endPos);
 		if (tag.type == Tag::Null) {
-			output += _template.midRef(lastTagEnd, endPos - lastTagEnd);
+			output += QStringView(_template).mid(lastTagEnd, endPos - lastTagEnd);
 			break;
 		}
-		output += _template.midRef(lastTagEnd, tag.start - lastTagEnd);
+		output += QStringView(_template).mid(lastTagEnd, tag.start - lastTagEnd);
 		switch (tag.type) {
 		case Tag::Value:
 		{

--- a/tests/test_mustache.cpp
+++ b/tests/test_mustache.cpp
@@ -482,7 +482,7 @@ void TestMustache::testConformance_data()
 		QJsonDocument document = QJsonDocument::fromJson(file.readAll());
 		QJsonArray testCaseValues = document.object()["tests"].toArray();
 
-		foreach (const QJsonValue &testCaseValue, testCaseValues) {
+		for (const QJsonValue &testCaseValue: testCaseValues) {
 			QJsonObject testCaseObject = testCaseValue.toObject();
 
 			QString name = fileName + " - " + testCaseObject["name"].toString();


### PR DESCRIPTION
These changes allow the code to compile against Qt 6 or Qt 5 using qmake. The CMake build has not yet been updated. Tested against Qt 5.15 and Qt 6.1. These changes are not Qt 4 compatible.

 - Replace QVariant type values with QMetaType counterparts
 - Replace removed `QString::midRef` with `QStringView(str).mid`
 - Change `QString::{count => length}`
 - Use range for loop to replace Q_FOREACH macro over a JSON array