### PR TITLE
listCount() should check if item is not a QString (Qt6)

### DIFF
--- a/src/mustache.cpp
+++ b/src/mustache.cpp
@@ -188,9 +188,9 @@ int QtVariantContext::listCount(const QString& key) const
 {
 	const QVariant& item = value(key);
 #if QT_VERSION >= 0x060000
-    if (item.canConvert<QVariantList>() && item.typeId() != QMetaType::QString) {
+	if (item.canConvert<QVariantList>() && item.typeId() != QMetaType::QString) {
 #else
-    if (item.canConvert<QVariantList>()) {
+	if (item.canConvert<QVariantList>()) {
 #endif
 		return item.toList().count();
 	}

--- a/src/mustache.cpp
+++ b/src/mustache.cpp
@@ -187,7 +187,11 @@ void QtVariantContext::pop()
 int QtVariantContext::listCount(const QString& key) const
 {
 	const QVariant& item = value(key);
-	if (item.canConvert<QVariantList>() && !item.canConvert<QString>()) {
+#if QT_VERSION >= 0x060000
+    if (item.canConvert<QVariantList>() && item.typeId() != QMetaType::QString) {
+#else
+    if (item.canConvert<QVariantList>()) {
+#endif
 		return item.toList().count();
 	}
 	return 0;

--- a/src/mustache.cpp
+++ b/src/mustache.cpp
@@ -187,7 +187,7 @@ void QtVariantContext::pop()
 int QtVariantContext::listCount(const QString& key) const
 {
 	const QVariant& item = value(key);
-	if (item.canConvert<QVariantList>()) {
+	if (item.canConvert<QVariantList>() && !item.canConvert<QString>()) {
 		return item.toList().count();
 	}
 	return 0;

--- a/src/mustache.cpp
+++ b/src/mustache.cpp
@@ -187,7 +187,7 @@ void QtVariantContext::pop()
 int QtVariantContext::listCount(const QString& key) const
 {
 	const QVariant& item = value(key);
-    if (item.canConvert<QVariantList>() && item.userType() != QMetaType::QString) {
+	if (item.canConvert<QVariantList>() && item.userType() != QMetaType::QString) {
 		return item.toList().count();
 	}
 	return 0;

--- a/src/mustache.cpp
+++ b/src/mustache.cpp
@@ -187,11 +187,7 @@ void QtVariantContext::pop()
 int QtVariantContext::listCount(const QString& key) const
 {
 	const QVariant& item = value(key);
-#if QT_VERSION >= 0x060000
-	if (item.canConvert<QVariantList>() && item.typeId() != QMetaType::QString) {
-#else
-	if (item.canConvert<QVariantList>()) {
-#endif
+    if (item.canConvert<QVariantList>() && item.userType() != QMetaType::QString) {
 		return item.toList().count();
 	}
 	return 0;

--- a/tests/test_mustache.cpp
+++ b/tests/test_mustache.cpp
@@ -119,6 +119,14 @@ void TestMustache::testSections()
 	QCOMPARE(output, expectedOutput);
 }
 
+void TestMustache::testSectionQString()
+{
+    QVariantHash data;
+    data["text"] = "test";
+    QString output = Mustache::renderTemplate("{{#text}}{{text}}{{/text}}", data);
+    QCOMPARE(output, QString("test"));
+}
+
 void TestMustache::testFalsiness()
 {
 	Mustache::Renderer renderer;

--- a/tests/test_mustache.cpp
+++ b/tests/test_mustache.cpp
@@ -121,10 +121,10 @@ void TestMustache::testSections()
 
 void TestMustache::testSectionQString()
 {
-    QVariantHash data;
-    data["text"] = "test";
-    QString output = Mustache::renderTemplate("{{#text}}{{text}}{{/text}}", data);
-    QCOMPARE(output, QString("test"));
+	QVariantHash data;
+	data["text"] = "test";
+	QString output = Mustache::renderTemplate("{{#text}}{{text}}{{/text}}", data);
+	QCOMPARE(output, QString("test"));
 }
 
 void TestMustache::testFalsiness()

--- a/tests/test_mustache.h
+++ b/tests/test_mustache.h
@@ -28,7 +28,7 @@ private Q_SLOTS:
 	void testPartialFile();
 	void testPartials();
 	void testSections();
-    void testSectionQString();
+	void testSectionQString();
 	void testFalsiness();
 	void testFloatValues();
 	void testSetDelimiters();

--- a/tests/test_mustache.h
+++ b/tests/test_mustache.h
@@ -28,6 +28,7 @@ private Q_SLOTS:
 	void testPartialFile();
 	void testPartials();
 	void testSections();
+    void testSectionQString();
 	void testFalsiness();
 	void testFloatValues();
 	void testSetDelimiters();


### PR DESCRIPTION
In Qt6 QString can be converted to QVariantList.

This causes sections like `{{#person}}...{{person}}...{{/person}}` to behave like lists if the item `person` is a string.
Here `..{{person}}...` is repeat as many times as there are characters in the item `person`.