### PR TITLE
BUGFIX in CMakeList.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
 )
 
-find_package(Qt6 COMPONENTS Core REQUIRED)
+find_package(Qt6 COMPONENTS Core)
 if (Qt6_FOUND)
   target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Core)
 else()


### PR DESCRIPTION
    Removed REQUIRED from "find_package(Qt6..."
    Due REQUIRED, if Qt6-NOTFOUND CMake breaks processing and exits with error. So "find_package(Qt5 ..." was unreachable