### PR TITLE
Various fixes and optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+build
+.qtcreator
 build-debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,14 +8,19 @@ set(CMAKE_AUTOMOC ON)
 
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
+include(GNUInstallDirs)
+
 set(QT_MUSTACHE_SOURCES
     src/mustache.h
     src/mustache.cpp
 )
 
 add_library(${PROJECT_NAME} ${QT_MUSTACHE_SOURCES})
+add_library(mustache::mustache ALIAS ${PROJECT_NAME})
+
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Core)
 
@@ -33,12 +38,24 @@ set(STRICT_COMPILE_DEFINITIONS
 target_compile_definitions(${PROJECT_NAME} PRIVATE ${STRICT_COMPILE_DEFINITIONS})
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_WARNING_AS_ERROR ON)
 
-# Tests
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-    include(CTest)
-endif()
+# Install rules
+install(TARGETS ${PROJECT_NAME}
+    EXPORT mustache-targets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+install(FILES src/mustache.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(EXPORT mustache-targets
+    NAMESPACE mustache::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mustache
+)
 
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
+# Tests — off by default when consumed as a dependency
+string(COMPARE EQUAL "${CMAKE_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}" _mustache_is_top_level)
+option(MUSTACHE_BUILD_TESTS "Build qt-mustache tests and benchmarks" ${_mustache_is_top_level})
+
+if(MUSTACHE_BUILD_TESTS)
     set(TEST_PROJECT_NAME "${PROJECT_NAME}_tests")
     enable_testing()
 
@@ -49,7 +66,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
         tests/test_mustache.h
     )
     add_test(${TEST_PROJECT_NAME} ${TEST_PROJECT_NAME})
-    target_link_libraries(${TEST_PROJECT_NAME} PRIVATE Qt6::Test ${PROJECT_NAME})
+    target_link_libraries(${TEST_PROJECT_NAME} PRIVATE Qt6::Test mustache::mustache)
     target_compile_definitions(${TEST_PROJECT_NAME} PRIVATE ${STRICT_COMPILE_DEFINITIONS})
     set_target_properties(${TEST_PROJECT_NAME} PROPERTIES COMPILE_WARNING_AS_ERROR ON)
 
@@ -64,7 +81,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
     add_executable(${BENCH_PROJECT_NAME}
         tests/bench_mustache.cpp
     )
-    target_link_libraries(${BENCH_PROJECT_NAME} PRIVATE Qt6::Test ${PROJECT_NAME})
+    target_link_libraries(${BENCH_PROJECT_NAME} PRIVATE Qt6::Test mustache::mustache)
     target_compile_definitions(${BENCH_PROJECT_NAME} PRIVATE ${STRICT_COMPILE_DEFINITIONS})
     set_target_properties(${BENCH_PROJECT_NAME} PROPERTIES COMPILE_WARNING_AS_ERROR ON)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,58 +1,70 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.19)
 
 project(qt-mustache LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_AUTOMOC ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Core)
 
 set(QT_MUSTACHE_SOURCES
     src/mustache.h
     src/mustache.cpp
-    )
-add_library(${PROJECT_NAME}
-    ${QT_MUSTACHE_SOURCES}
-    )
-target_include_directories(${PROJECT_NAME} PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
 )
 
-find_package(Qt6 COMPONENTS Core)
-if (Qt6_FOUND)
-  target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Core)
-else()
-  find_package(Qt5 COMPONENTS Core REQUIRED)
-  target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Core)
-endif()
+add_library(${PROJECT_NAME} ${QT_MUSTACHE_SOURCES})
+target_include_directories(${PROJECT_NAME} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Core)
 
-#tests related stuff
+set(STRICT_COMPILE_DEFINITIONS
+    QT_NO_CAST_FROM_ASCII
+    QT_NO_CAST_TO_ASCII
+    QT_NO_CAST_FROM_BYTEARRAY
+    QT_NO_URL_CAST_FROM_STRING
+    QT_NO_CONTEXTLESS_CONNECT
+    QT_NO_NARROWING_CONVERSIONS_IN_CONNECT
+    QT_NO_QSNPRINTF
+    QT_STRICT_ITERATORS
+)
+
+target_compile_definitions(${PROJECT_NAME} PRIVATE ${STRICT_COMPILE_DEFINITIONS})
+set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_WARNING_AS_ERROR ON)
+
+# Tests
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     include(CTest)
 endif()
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
-    SET(TEST_PROPJECT_NAME "${PROJECT_NAME}_tests")
+    set(TEST_PROJECT_NAME "${PROJECT_NAME}_tests")
     enable_testing()
 
-    if (Qt6_FOUND)
-      find_package(Qt6Test REQUIRED)
-    else()
-      find_package(Qt5Test REQUIRED)
-    endif()
+    find_package(Qt6 REQUIRED COMPONENTS Test)
 
-    add_executable(${TEST_PROPJECT_NAME}
+    add_executable(${TEST_PROJECT_NAME}
         tests/test_mustache.cpp
         tests/test_mustache.h
     )
-    add_test(${TEST_PROPJECT_NAME} ${TEST_PROPJECT_NAME})
-
-    if (Qt6_FOUND)
-      target_link_libraries(${TEST_PROPJECT_NAME} Qt6::Test ${PROJECT_NAME})
-    else()
-      target_link_libraries(${TEST_PROPJECT_NAME} Qt5::Test ${PROJECT_NAME})
-    endif()
+    add_test(${TEST_PROJECT_NAME} ${TEST_PROJECT_NAME})
+    target_link_libraries(${TEST_PROJECT_NAME} PRIVATE Qt6::Test ${PROJECT_NAME})
+    target_compile_definitions(${TEST_PROJECT_NAME} PRIVATE ${STRICT_COMPILE_DEFINITIONS})
+    set_target_properties(${TEST_PROJECT_NAME} PROPERTIES COMPILE_WARNING_AS_ERROR ON)
 
     file(GLOB TEST_CONTENTS
         "tests/specs/*.json"
         "tests/partial.mustache"
     )
     file(COPY ${TEST_CONTENTS} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+    # Benchmarks
+    set(BENCH_PROJECT_NAME "${PROJECT_NAME}_bench")
+    add_executable(${BENCH_PROJECT_NAME}
+        tests/bench_mustache.cpp
+    )
+    target_link_libraries(${BENCH_PROJECT_NAME} PRIVATE Qt6::Test ${PROJECT_NAME})
+    target_compile_definitions(${BENCH_PROJECT_NAME} PRIVATE ${STRICT_COMPILE_DEFINITIONS})
+    set_target_properties(${BENCH_PROJECT_NAME} PROPERTIES COMPILE_WARNING_AS_ERROR ON)
 endif()

--- a/src/mustache.cpp
+++ b/src/mustache.cpp
@@ -22,10 +22,11 @@ using namespace Qt::StringLiterals;
 
 using namespace Mustache;
 
-QString Mustache::renderTemplate(const QString &templateString, const QVariantHash &args)
+QString Mustache::renderTemplate(const QString &templateString, const QVariantHash &args,
+                                 Tag::EscapeMode defaultEscapeMode)
 {
     Mustache::QtVariantContext context(args);
-    Mustache::Renderer renderer;
+    Mustache::Renderer renderer(defaultEscapeMode);
     return renderer.render(templateString, &context);
 }
 
@@ -250,10 +251,11 @@ QString PartialFileLoader::getPartial(const QString &name)
     return m_cache.value(name);
 }
 
-Renderer::Renderer()
+Renderer::Renderer(Tag::EscapeMode defaultEscapeMode)
     : m_errorPos(-1)
     , m_defaultTagStartMarker(u"{{"_s)
     , m_defaultTagEndMarker(u"}}"_s)
+    , m_defaultEscapeMode(defaultEscapeMode)
 {
 }
 
@@ -431,6 +433,7 @@ Tag Renderer::findTag(const QString &content, int pos, int endPos)
     tag.type = Tag::Value;
     tag.start = tagStartPos;
     tag.end = tagEndPos;
+    tag.escapeMode = m_defaultEscapeMode;
 
     pos = tagStartPos + m_tagStartMarker.length();
     endPos = tagEndPos - m_tagEndMarker.length();

--- a/src/mustache.cpp
+++ b/src/mustache.cpp
@@ -4,12 +4,12 @@
   Redistribution and use in source and binary forms, with or without modification,
   are permitted provided that the following conditions are met:
 
-    Redistributions of source code must retain the above copyright notice,
-    this list of conditions and the following disclaimer.
+  Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
 
-    Redistributions in binary form must reproduce the above copyright notice,
-    this list of conditions and the following disclaimer in the documentation
-    and/or other materials provided with the distribution.
+  Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
 */
 
 #include "mustache.h"
@@ -19,560 +19,560 @@
 #include <QtCore/QStringList>
 #include <QtCore/QTextStream>
 
+using namespace Qt::StringLiterals;
+
 using namespace Mustache;
 
-QString Mustache::renderTemplate(const QString& templateString, const QVariantHash& args)
+QString Mustache::renderTemplate(const QString &templateString, const QVariantHash &args)
 {
-	Mustache::QtVariantContext context(args);
-	Mustache::Renderer renderer;
-	return renderer.render(templateString, &context);
+    Mustache::QtVariantContext context(args);
+    Mustache::Renderer renderer;
+    return renderer.render(templateString, &context);
 }
 
-QString escapeHtml(const QString& input)
+QString Mustache::escapeHtml(const QString &input)
 {
-	QString escaped(input);
-	for (int i=0; i < escaped.length();) {
-		const char* replacement = 0;
-		ushort ch = escaped.at(i).unicode();
-		if (ch == '&') {
-			replacement = "&amp;";
-		} else if (ch == '<') {
-			replacement = "&lt;";
-		} else if (ch == '>') {
-			replacement = "&gt;";
-		} else if (ch == '"') {
-			replacement = "&quot;";
-		}
-		if (replacement) {
-			escaped.replace(i, 1, QLatin1String(replacement));
-			i += (int)strlen(replacement);
-		} else {
-			++i;
-		}
-	}
-	return escaped;
+    QString escaped(input);
+    for (int i = 0; i < escaped.length();) {
+        std::u16string_view replacement;
+        ushort ch = escaped.at(i).unicode();
+        if (ch == u'&') {
+            replacement = u"&amp;";
+        } else if (ch == u'<') {
+            replacement = u"&lt;";
+        } else if (ch == u'>') {
+            replacement = u"&gt;";
+        } else if (ch == u'"') {
+            replacement = u"&quot;";
+        }
+        if (!replacement.empty()) {
+            escaped.replace(i, 1, QString::fromUtf16(replacement.data(), replacement.size()));
+            i += replacement.size();
+        } else {
+            ++i;
+        }
+    }
+    return escaped;
 }
 
-QString unescapeHtml(const QString& escaped)
+QString Mustache::unescapeHtml(const QString &escaped)
 {
-	QString unescaped(escaped);
-	unescaped.replace(QLatin1String("&lt;"), QLatin1String("<"));
-	unescaped.replace(QLatin1String("&gt;"), QLatin1String(">"));
-	unescaped.replace(QLatin1String("&quot;"), QLatin1String("\""));
-	unescaped.replace(QLatin1String("&amp;"), QLatin1String("&"));
-	return unescaped;
+    QString unescaped(escaped);
+    unescaped.replace(QLatin1String("&lt;"), QLatin1String("<"));
+    unescaped.replace(QLatin1String("&gt;"), QLatin1String(">"));
+    unescaped.replace(QLatin1String("&quot;"), QLatin1String("\""));
+    unescaped.replace(QLatin1String("&amp;"), QLatin1String("&"));
+    return unescaped;
 }
 
-Context::Context(PartialResolver* resolver)
-	: m_partialResolver(resolver)
-{}
-
-PartialResolver* Context::partialResolver() const
+Context::Context(PartialResolver *resolver)
+    : m_partialResolver(resolver)
 {
-	return m_partialResolver;
 }
 
-QString Context::partialValue(const QString& key) const
+PartialResolver *Context::partialResolver() const
 {
-	if (!m_partialResolver) {
-		return QString();
-	}
-	return m_partialResolver->getPartial(key);
+    return m_partialResolver;
 }
 
-bool Context::canEval(const QString&) const
+QString Context::partialValue(const QString &key) const
 {
-	return false;
+    if (!m_partialResolver) {
+        return {};
+    }
+    return m_partialResolver->getPartial(key);
 }
 
-QString Context::eval(const QString& key, const QString& _template, Renderer* renderer)
+bool Context::canEval(const QString &) const
 {
-	Q_UNUSED(key);
-	Q_UNUSED(_template);
-	Q_UNUSED(renderer);
-
-	return QString();
+    return false;
 }
 
-QtVariantContext::QtVariantContext(const QVariant& root, PartialResolver* resolver)
-	: Context(resolver)
+QString Context::eval(const QString &key, const QString &_template, Renderer *renderer)
 {
-	m_contextStack << root;
+    Q_UNUSED(key);
+    Q_UNUSED(_template);
+    Q_UNUSED(renderer);
+
+    return {};
 }
 
-QVariant variantMapValue(const QVariant& value, const QString& key)
+QtVariantContext::QtVariantContext(const QVariant &root, PartialResolver *resolver)
+    : Context(resolver)
 {
-	if (value.userType() == QMetaType::QVariantMap) {
-		return value.toMap().value(key);
-	} else {
-		return value.toHash().value(key);
-	}
+    m_contextStack << root;
 }
 
-QVariant variantMapValueForKeyPath(const QVariant& value, const QStringList keyPath)
+QVariant variantMapValue(const QVariant &value, const QString &key)
 {
-	if (keyPath.count() > 1) {
-		QVariant firstValue = variantMapValue(value, keyPath.first());
-		return firstValue.isNull() ? QVariant() : variantMapValueForKeyPath(firstValue, keyPath.mid(1));
-	} else if (!keyPath.isEmpty()) {
-		return variantMapValue(value, keyPath.first());
-	}
-	return QVariant();
+    if (value.userType() == QMetaType::QVariantMap) {
+        return value.toMap().value(key);
+    } else {
+        return value.toHash().value(key);
+    }
 }
 
-QVariant QtVariantContext::value(const QString& key) const
+QVariant variantMapValueForKeyPath(const QVariant &value, const QStringList &keyPath)
 {
-	if (key == "." && !m_contextStack.isEmpty()) {
-		return m_contextStack.last();
-	}
-	QStringList keyPath = key.split(".");
-	for (int i = m_contextStack.count()-1; i >= 0; i--) {
-		QVariant value = variantMapValueForKeyPath(m_contextStack.at(i), keyPath);
-		if (!value.isNull()) {
-			return value;
-		}
-	}
-	return QVariant();
+    if (keyPath.count() > 1) {
+        QVariant firstValue = variantMapValue(value, keyPath.first());
+        return firstValue.isNull() ? QVariant() : variantMapValueForKeyPath(firstValue, keyPath.mid(1));
+    } else if (!keyPath.isEmpty()) {
+        return variantMapValue(value, keyPath.first());
+    }
+    return {};
 }
 
-bool QtVariantContext::isFalse(const QString& key) const
+QVariant QtVariantContext::value(const QString &key) const
 {
-	QVariant value = this->value(key);
-	switch (value.userType()) {
-	case QMetaType::Double:
-	case QMetaType::Float:
-		// QVariant::toBool() rounds floats to the nearest int and then compares
-		// against 0, which is not the falsiness behavior we want.
-		return value.toDouble() == 0.;
-	case QMetaType::QChar:
-	case QMetaType::Int:
-	case QMetaType::UInt:
-	case QMetaType::LongLong:
-	case QMetaType::ULongLong:
-	case QMetaType::Bool:
-		return !value.toBool();
-	case QMetaType::QVariantList:
-	case QMetaType::QStringList:
-		return value.toList().isEmpty();
-	case QMetaType::QVariantHash:
-		return value.toHash().isEmpty();
-	case QMetaType::QVariantMap:
-		return value.toMap().isEmpty();
-	default:
-		return value.toString().isEmpty();
-	}
+    if (key == u"."_s && !m_contextStack.isEmpty()) {
+        return m_contextStack.last();
+    }
+    QStringList keyPath = key.split(u"."_s);
+    for (int i = m_contextStack.count() - 1; i >= 0; i--) {
+        QVariant value = variantMapValueForKeyPath(m_contextStack.at(i), keyPath);
+        if (!value.isNull()) {
+            return value;
+        }
+    }
+    return {};
 }
 
-QString QtVariantContext::stringValue(const QString& key) const
+bool QtVariantContext::isFalse(const QString &key) const
 {
-	return value(key).toString();
+    QVariant value = this->value(key);
+    switch (value.userType()) {
+    case QMetaType::Double:
+    case QMetaType::Float:
+        // QVariant::toBool() rounds floats to the nearest int and then compares
+        // against 0, which is not the falsiness behavior we want.
+        return value.toDouble() == 0.;
+    case QMetaType::QChar:
+    case QMetaType::Int:
+    case QMetaType::UInt:
+    case QMetaType::LongLong:
+    case QMetaType::ULongLong:
+    case QMetaType::Bool:
+        return !value.toBool();
+    case QMetaType::QVariantList:
+    case QMetaType::QStringList:
+        return value.toList().isEmpty();
+    case QMetaType::QVariantHash:
+        return value.toHash().isEmpty();
+    case QMetaType::QVariantMap:
+        return value.toMap().isEmpty();
+    default:
+        return value.toString().isEmpty();
+    }
 }
 
-void QtVariantContext::push(const QString& key, int index)
+QString QtVariantContext::stringValue(const QString &key) const
 {
-	QVariant mapItem = value(key);
-	if (index == -1) {
-		m_contextStack << mapItem;
-	} else {
-		QVariantList list = mapItem.toList();
-		m_contextStack << list.value(index, QVariant());
-	}
+    return value(key).toString();
+}
+
+void QtVariantContext::push(const QString &key, int index)
+{
+    QVariant mapItem = value(key);
+    if (index == -1) {
+        m_contextStack << mapItem;
+    } else {
+        QVariantList list = mapItem.toList();
+        m_contextStack << list.value(index, QVariant());
+    }
 }
 
 void QtVariantContext::pop()
 {
-	m_contextStack.pop();
+    m_contextStack.pop();
 }
 
-int QtVariantContext::listCount(const QString& key) const
+int QtVariantContext::listCount(const QString &key) const
 {
-	const QVariant& item = value(key);
-	if (item.canConvert<QVariantList>() && item.userType() != QMetaType::QString) {
-		return item.toList().count();
-	}
-	return 0;
+    const QVariant &item = value(key);
+    if (item.canConvert<QVariantList>() && item.userType() != QMetaType::QString) {
+        return item.toList().count();
+    }
+    return 0;
 }
 
-bool QtVariantContext::canEval(const QString& key) const
+bool QtVariantContext::canEval(const QString &key) const
 {
-	return value(key).canConvert<fn_t>();
+    return value(key).canConvert<fn_t>();
 }
 
-QString QtVariantContext::eval(const QString& key, const QString& _template, Renderer* renderer)
+QString QtVariantContext::eval(const QString &key, const QString &_template, Renderer *renderer)
 {
-	QVariant fn = value(key);
-	if (fn.isNull()) {
-		return QString();
-	}
-	return fn.value<fn_t>()(_template, renderer, this);
+    QVariant fn = value(key);
+    if (fn.isNull()) {
+        return {};
+    }
+    return fn.value<fn_t>()(_template, renderer, this);
 }
 
-PartialMap::PartialMap(const QHash<QString, QString>& partials)
-	: m_partials(partials)
-{}
-
-QString PartialMap::getPartial(const QString& name)
+PartialMap::PartialMap(const QHash<QString, QString> &partials)
+    : m_partials(partials)
 {
-	return m_partials.value(name);
 }
 
-PartialFileLoader::PartialFileLoader(const QString& basePath)
-	: m_basePath(basePath)
-{}
-
-QString PartialFileLoader::getPartial(const QString& name)
+QString PartialMap::getPartial(const QString &name)
 {
-	if (!m_cache.contains(name)) {
-		QString path = m_basePath + '/' + name + ".mustache";
-		QFile file(path);
-		if (file.open(QIODevice::ReadOnly)) {
-			QTextStream stream(&file);
-			m_cache.insert(name, stream.readAll());
-		}
-	}
-	return m_cache.value(name);
+    return m_partials.value(name);
+}
+
+PartialFileLoader::PartialFileLoader(const QString &basePath)
+    : m_basePath(basePath)
+{
+}
+
+QString PartialFileLoader::getPartial(const QString &name)
+{
+    if (!m_cache.contains(name)) {
+        QString path = m_basePath + u'/' + name + u".mustache"_s;
+        QFile file(path);
+        if (file.open(QIODevice::ReadOnly)) {
+            QTextStream stream(&file);
+            m_cache.insert(name, stream.readAll());
+        }
+    }
+    return m_cache.value(name);
 }
 
 Renderer::Renderer()
-	: m_errorPos(-1)
-	, m_defaultTagStartMarker("{{")
-	, m_defaultTagEndMarker("}}")
+    : m_errorPos(-1)
+    , m_defaultTagStartMarker(u"{{"_s)
+    , m_defaultTagEndMarker(u"}}"_s)
 {
 }
 
 QString Renderer::error() const
 {
-	return m_error;
+    return m_error;
 }
 
 int Renderer::errorPos() const
 {
-	return m_errorPos;
+    return m_errorPos;
 }
 
 QString Renderer::errorPartial() const
 {
-	return m_errorPartial;
+    return m_errorPartial;
 }
 
-QString Renderer::render(const QString& _template, Context* context)
+QString Renderer::render(const QString &_template, Context *context)
 {
-	m_error.clear();
-	m_errorPos = -1;
-	m_errorPartial.clear();
+    m_error.clear();
+    m_errorPos = -1;
+    m_errorPartial.clear();
 
-	m_tagStartMarker = m_defaultTagStartMarker;
-	m_tagEndMarker = m_defaultTagEndMarker;
+    m_tagStartMarker = m_defaultTagStartMarker;
+    m_tagEndMarker = m_defaultTagEndMarker;
 
-	return render(_template, 0, _template.length(), context);
+    return render(_template, 0, _template.length(), context);
 }
 
-QString Renderer::render(const QString& _template, int startPos, int endPos, Context* context)
+QString Renderer::render(const QString &_template, int startPos, int endPos, Context *context)
 {
-	QString output;
-	int lastTagEnd = startPos;
+    QString output;
+    int lastTagEnd = startPos;
 
-	while (m_errorPos == -1) {
-		Tag tag = findTag(_template, lastTagEnd, endPos);
-		if (tag.type == Tag::Null) {
-			output += QStringView(_template).mid(lastTagEnd, endPos - lastTagEnd);
-			break;
-		}
-		output += QStringView(_template).mid(lastTagEnd, tag.start - lastTagEnd);
-		switch (tag.type) {
-		case Tag::Value:
-		{
-			QString value = context->stringValue(tag.key);
-			if (tag.escapeMode == Tag::Escape) {
-				value = escapeHtml(value);
-			} else if (tag.escapeMode == Tag::Unescape) {
-				value = unescapeHtml(value);
-			}
-			output += value;
-			lastTagEnd = tag.end;
-		}
-		break;
-		case Tag::SectionStart:
-		{
-			Tag endTag = findEndTag(_template, tag, endPos);
-			if (endTag.type == Tag::Null) {
-				if (m_errorPos == -1) {
-					setError("No matching end tag found for section", tag.start);
-				}
-			} else {
-				int listCount = context->listCount(tag.key);
-				if (listCount > 0) {
-					for (int i=0; i < listCount; i++) {
-						context->push(tag.key, i);
-						output += render(_template, tag.end, endTag.start, context);
-						context->pop();
-					}
-				} else if (context->canEval(tag.key)) {
-					output += context->eval(tag.key, _template.mid(tag.end, endTag.start - tag.end), this);
-				} else if (!context->isFalse(tag.key)) {
-					context->push(tag.key);
-					output += render(_template, tag.end, endTag.start, context);
-					context->pop();
-				}
-				lastTagEnd = endTag.end;
-			}
-		}
-		break;
-		case Tag::InvertedSectionStart:
-		{
-			Tag endTag = findEndTag(_template, tag, endPos);
-			if (endTag.type == Tag::Null) {
-				if (m_errorPos == -1) {
-					setError("No matching end tag found for inverted section", tag.start);
-				}
-			} else {
-				if (context->isFalse(tag.key)) {
-					output += render(_template, tag.end, endTag.start, context);
-				}
-				lastTagEnd = endTag.end;
-			}
-		}
-		break;
-		case Tag::SectionEnd:
-			setError("Unexpected end tag", tag.start);
-			lastTagEnd = tag.end;
-			break;
-		case Tag::Partial:
-		{
-			QString tagStartMarker = m_tagStartMarker;
-			QString tagEndMarker = m_tagEndMarker;
+    while (m_errorPos == -1) {
+        Tag tag = findTag(_template, lastTagEnd, endPos);
+        if (tag.type == Tag::Null) {
+            output += QStringView(_template).mid(lastTagEnd, endPos - lastTagEnd);
+            break;
+        }
+        output += QStringView(_template).mid(lastTagEnd, tag.start - lastTagEnd);
+        switch (tag.type) {
+        case Tag::Value: {
+            QString value = context->stringValue(tag.key);
+            if (tag.escapeMode == Tag::Escape) {
+                value = escapeHtml(value);
+            } else if (tag.escapeMode == Tag::Unescape) {
+                value = unescapeHtml(value);
+            }
+            output += value;
+            lastTagEnd = tag.end;
+        } break;
+        case Tag::SectionStart: {
+            Tag endTag = findEndTag(_template, tag, endPos);
+            if (endTag.type == Tag::Null) {
+                if (m_errorPos == -1) {
+                    setError(u"No matching end tag found for section"_s, tag.start);
+                }
+            } else {
+                int listCount = context->listCount(tag.key);
+                if (listCount > 0) {
+                    for (int i = 0; i < listCount; i++) {
+                        context->push(tag.key, i);
+                        output += render(_template, tag.end, endTag.start, context);
+                        context->pop();
+                    }
+                } else if (context->canEval(tag.key)) {
+                    output += context->eval(tag.key, _template.mid(tag.end, endTag.start - tag.end), this);
+                } else if (!context->isFalse(tag.key)) {
+                    context->push(tag.key);
+                    output += render(_template, tag.end, endTag.start, context);
+                    context->pop();
+                }
+                lastTagEnd = endTag.end;
+            }
+        } break;
+        case Tag::InvertedSectionStart: {
+            Tag endTag = findEndTag(_template, tag, endPos);
+            if (endTag.type == Tag::Null) {
+                if (m_errorPos == -1) {
+                    setError(u"No matching end tag found for inverted section"_s, tag.start);
+                }
+            } else {
+                if (context->isFalse(tag.key)) {
+                    output += render(_template, tag.end, endTag.start, context);
+                }
+                lastTagEnd = endTag.end;
+            }
+        } break;
+        case Tag::SectionEnd:
+            setError(u"Unexpected end tag"_s, tag.start);
+            lastTagEnd = tag.end;
+            break;
+        case Tag::Partial: {
+            QString tagStartMarker = m_tagStartMarker;
+            QString tagEndMarker = m_tagEndMarker;
 
-			m_tagStartMarker = m_defaultTagStartMarker;
-			m_tagEndMarker = m_defaultTagEndMarker;
+            m_tagStartMarker = m_defaultTagStartMarker;
+            m_tagEndMarker = m_defaultTagEndMarker;
 
-			m_partialStack.push(tag.key);
+            m_partialStack.push(tag.key);
 
-			QString partialContent = context->partialValue(tag.key);
+            QString partialContent = context->partialValue(tag.key);
 
-			// If there is a need to add a special indentation to the partial
-			if (tag.indentation > 0) {
-				output += QString(" ").repeated(tag.indentation);
-				// Indenting the output to keep the parent indentation.
-				int posOfLF = partialContent.indexOf("\n", 0);
-				while (posOfLF > 0 && posOfLF < (partialContent.length() - 1)) { // .length() - 1 because we dont want indentation AFTER the last character if it's a LF
-					partialContent = partialContent.insert(posOfLF + 1, QString(" ").repeated(tag.indentation));
-					posOfLF = partialContent.indexOf("\n", posOfLF + 1);
-				}
-			}
+            // If there is a need to add a special indentation to the partial
+            if (tag.indentation > 0) {
+                output += u" "_s.repeated(tag.indentation);
+                // Indenting the output to keep the parent indentation.
+                int posOfLF = partialContent.indexOf(u'\n', 0);
+                while (
+                    posOfLF > 0 &&
+                    posOfLF <
+                        (partialContent.length() -
+                         1)) { // .length() - 1 because we dont want indentation AFTER the last character if it's a LF
+                    partialContent = partialContent.insert(posOfLF + 1, u" "_s.repeated(tag.indentation));
+                    posOfLF = partialContent.indexOf(u'\n', posOfLF + 1);
+                }
+            }
 
-			QString partialRendered = render(partialContent, 0, partialContent.length(), context);
+            QString partialRendered = render(partialContent, 0, partialContent.length(), context);
 
-			output += partialRendered;
+            output += partialRendered;
 
-			lastTagEnd = tag.end;
+            lastTagEnd = tag.end;
 
-			m_partialStack.pop();
+            m_partialStack.pop();
 
-			m_tagStartMarker = tagStartMarker;
-			m_tagEndMarker = tagEndMarker;
-		}
-		break;
-		case Tag::SetDelimiter:
-			lastTagEnd = tag.end;
-			break;
-		case Tag::Comment:
-			lastTagEnd = tag.end;
-			break;
-		case Tag::Null:
-			break;
-		}
-	}
+            m_tagStartMarker = tagStartMarker;
+            m_tagEndMarker = tagEndMarker;
+        } break;
+        case Tag::SetDelimiter:
+            lastTagEnd = tag.end;
+            break;
+        case Tag::Comment:
+            lastTagEnd = tag.end;
+            break;
+        case Tag::Null:
+            break;
+        }
+    }
 
-	return output;
+    return output;
 }
 
-void Renderer::setError(const QString& error, int pos)
+void Renderer::setError(const QString &error, int pos)
 {
-	Q_ASSERT(!error.isEmpty());
-	Q_ASSERT(pos >= 0);
+    Q_ASSERT(!error.isEmpty());
+    Q_ASSERT(pos >= 0);
 
-	m_error = error;
-	m_errorPos = pos;
+    m_error = error;
+    m_errorPos = pos;
 
-	if (!m_partialStack.isEmpty())
-	{
-		m_errorPartial = m_partialStack.top();
-	}
+    if (!m_partialStack.isEmpty()) {
+        m_errorPartial = m_partialStack.top();
+    }
 }
 
-Tag Renderer::findTag(const QString& content, int pos, int endPos)
+Tag Renderer::findTag(const QString &content, int pos, int endPos)
 {
-	int tagStartPos = content.indexOf(m_tagStartMarker, pos);
-	if (tagStartPos == -1 || tagStartPos >= endPos) {
-		return Tag();
-	}
+    int tagStartPos = content.indexOf(m_tagStartMarker, pos);
+    if (tagStartPos == -1 || tagStartPos >= endPos) {
+        return {};
+    }
 
-	int tagEndPos = content.indexOf(m_tagEndMarker, tagStartPos + m_tagStartMarker.length());
-	if (tagEndPos == -1) {
-		return Tag();
-	}
-	tagEndPos += m_tagEndMarker.length();
+    int tagEndPos = content.indexOf(m_tagEndMarker, tagStartPos + m_tagStartMarker.length());
+    if (tagEndPos == -1) {
+        return {};
+    }
+    tagEndPos += m_tagEndMarker.length();
 
-	Tag tag;
-	tag.type = Tag::Value;
-	tag.start = tagStartPos;
-	tag.end = tagEndPos;
+    Tag tag;
+    tag.type = Tag::Value;
+    tag.start = tagStartPos;
+    tag.end = tagEndPos;
 
-	pos = tagStartPos + m_tagStartMarker.length();
-	endPos = tagEndPos - m_tagEndMarker.length();
+    pos = tagStartPos + m_tagStartMarker.length();
+    endPos = tagEndPos - m_tagEndMarker.length();
 
-	QChar typeChar = content.at(pos);
+    QChar typeChar = content.at(pos);
 
-	if (typeChar == '#') {
-		tag.type = Tag::SectionStart;
-		tag.key = readTagName(content, pos+1, endPos);
-	} else if (typeChar == '^') {
-		tag.type = Tag::InvertedSectionStart;
-		tag.key = readTagName(content, pos+1, endPos);
-	} else if (typeChar == '/') {
-		tag.type = Tag::SectionEnd;
-		tag.key = readTagName(content, pos+1, endPos);
-	} else if (typeChar == '!') {
-		tag.type = Tag::Comment;
-	} else if (typeChar == '>') {
-		tag.type = Tag::Partial;
-		tag.key = readTagName(content, pos+1, endPos);
-	} else if (typeChar == '=') {
-		tag.type = Tag::SetDelimiter;
-		readSetDelimiter(content, pos+1, tagEndPos - m_tagEndMarker.length());
-	} else {
-		if (typeChar == '&') {
-			tag.escapeMode = Tag::Unescape;
-			++pos;
-		} else if (typeChar == '{') {
-			tag.escapeMode = Tag::Raw;
-			++pos;
-			int endTache = content.indexOf('}', pos);
-			if (endTache == tag.end - m_tagEndMarker.length()) {
-				++tag.end;
-			} else {
-				endPos = endTache;
-			}
-		}
-		tag.type = Tag::Value;
-		tag.key = readTagName(content, pos, endPos);
-	}
+    if (typeChar == '#') {
+        tag.type = Tag::SectionStart;
+        tag.key = readTagName(content, pos + 1, endPos);
+    } else if (typeChar == '^') {
+        tag.type = Tag::InvertedSectionStart;
+        tag.key = readTagName(content, pos + 1, endPos);
+    } else if (typeChar == '/') {
+        tag.type = Tag::SectionEnd;
+        tag.key = readTagName(content, pos + 1, endPos);
+    } else if (typeChar == '!') {
+        tag.type = Tag::Comment;
+    } else if (typeChar == '>') {
+        tag.type = Tag::Partial;
+        tag.key = readTagName(content, pos + 1, endPos);
+    } else if (typeChar == '=') {
+        tag.type = Tag::SetDelimiter;
+        readSetDelimiter(content, pos + 1, tagEndPos - m_tagEndMarker.length());
+    } else {
+        if (typeChar == '&') {
+            tag.escapeMode = Tag::Unescape;
+            ++pos;
+        } else if (typeChar == '{') {
+            tag.escapeMode = Tag::Raw;
+            ++pos;
+            int endTache = content.indexOf('}', pos);
+            if (endTache == tag.end - m_tagEndMarker.length()) {
+                ++tag.end;
+            } else {
+                endPos = endTache;
+            }
+        }
+        tag.type = Tag::Value;
+        tag.key = readTagName(content, pos, endPos);
+    }
 
-	if (tag.type != Tag::Value) {
-		expandTag(tag, content);
-	}
+    if (tag.type != Tag::Value) {
+        expandTag(tag, content);
+    }
 
-	return tag;
+    return tag;
 }
 
-QString Renderer::readTagName(const QString& content, int pos, int endPos)
+QString Renderer::readTagName(const QString &content, int pos, int endPos)
 {
-	QString name;
-	name.reserve(endPos - pos);
-	while (content.at(pos).isSpace()) {
-		++pos;
-	}
-	while (!content.at(pos).isSpace() && pos < endPos) {
-		name += content.at(pos);
-		++pos;
-	}
-	return name;
+    QString name;
+    name.reserve(endPos - pos);
+    while (content.at(pos).isSpace()) {
+        ++pos;
+    }
+    while (!content.at(pos).isSpace() && pos < endPos) {
+        name += content.at(pos);
+        ++pos;
+    }
+    return name;
 }
 
-void Renderer::readSetDelimiter(const QString& content, int pos, int endPos)
+void Renderer::readSetDelimiter(const QString &content, int pos, int endPos)
 {
-	QString startMarker;
-	QString endMarker;
+    QString startMarker;
+    QString endMarker;
 
-	while (content.at(pos).isSpace() && pos < endPos) {
-		++pos;
-	}
+    while (content.at(pos).isSpace() && pos < endPos) {
+        ++pos;
+    }
 
-	while (!content.at(pos).isSpace() && pos < endPos) {
-		if (content.at(pos) == '=') {
-			setError("Custom delimiters may not contain '='.", pos);
-			return;
-		}
-		startMarker += content.at(pos);
-		++pos;
-	}
+    while (!content.at(pos).isSpace() && pos < endPos) {
+        if (content.at(pos) == '=') {
+            setError(u"Custom delimiters may not contain '='."_s, pos);
+            return;
+        }
+        startMarker += content.at(pos);
+        ++pos;
+    }
 
-	while (content.at(pos).isSpace() && pos < endPos) {
-		++pos;
-	}
+    while (content.at(pos).isSpace() && pos < endPos) {
+        ++pos;
+    }
 
-	while (!content.at(pos).isSpace() && pos < endPos - 1) {
-		if (content.at(pos) == '=') {
-			setError("Custom delimiters may not contain '='.", pos);
-			return;
-		}
-		endMarker += content.at(pos);
-		++pos;
-	}
+    while (!content.at(pos).isSpace() && pos < endPos - 1) {
+        if (content.at(pos) == '=') {
+            setError(u"Custom delimiters may not contain '='."_s, pos);
+            return;
+        }
+        endMarker += content.at(pos);
+        ++pos;
+    }
 
-	m_tagStartMarker = startMarker;
-	m_tagEndMarker = endMarker;
+    m_tagStartMarker = startMarker;
+    m_tagEndMarker = endMarker;
 }
 
-Tag Renderer::findEndTag(const QString& content, const Tag& startTag, int endPos)
+Tag Renderer::findEndTag(const QString &content, const Tag &startTag, int endPos)
 {
-	int tagDepth = 1;
-	int pos = startTag.end;
+    int tagDepth = 1;
+    int pos = startTag.end;
 
-	while (true) {
-		Tag nextTag = findTag(content, pos, endPos);
-		if (nextTag.type == Tag::Null) {
-			return nextTag;
-		} else if (nextTag.type == Tag::SectionStart || nextTag.type == Tag::InvertedSectionStart) {
-			++tagDepth;
-		} else if (nextTag.type == Tag::SectionEnd) {
-			--tagDepth;
-			if (tagDepth == 0) {
-				if (nextTag.key != startTag.key) {
-					setError("Tag start/end key mismatch", nextTag.start);
-					return Tag();
-				}
-				return nextTag;
-			}
-		}
-		pos = nextTag.end;
-	}
+    while (true) {
+        Tag nextTag = findTag(content, pos, endPos);
+        if (nextTag.type == Tag::Null) {
+            return nextTag;
+        } else if (nextTag.type == Tag::SectionStart || nextTag.type == Tag::InvertedSectionStart) {
+            ++tagDepth;
+        } else if (nextTag.type == Tag::SectionEnd) {
+            --tagDepth;
+            if (tagDepth == 0) {
+                if (nextTag.key != startTag.key) {
+                    setError(u"Tag start/end key mismatch"_s, nextTag.start);
+                    return {};
+                }
+                return nextTag;
+            }
+        }
+        pos = nextTag.end;
+    }
 
-	return Tag();
+    return {};
 }
 
-void Renderer::setTagMarkers(const QString& startMarker, const QString& endMarker)
+void Renderer::setTagMarkers(const QString &startMarker, const QString &endMarker)
 {
-	m_defaultTagStartMarker = startMarker;
-	m_defaultTagEndMarker = endMarker;
+    m_defaultTagStartMarker = startMarker;
+    m_defaultTagEndMarker = endMarker;
 }
 
-void Renderer::expandTag(Tag& tag, const QString& content)
+void Renderer::expandTag(Tag &tag, const QString &content)
 {
-	int start = tag.start;
-	int end = tag.end;
-	int indentation = 0;
+    int start = tag.start;
+    int end = tag.end;
+    int indentation = 0;
 
-	// Move start to beginning of line.
-	while (start > 0 && content.at(start - 1) != QLatin1Char('\n')) {
-		--start;
-		if (!content.at(start).isSpace()) {
-			return; // Not standalone.
-		} else if (content.at(start).category() == QChar::Separator_Space) {
-			// If its an actual "white space" and not a new line, it counts toward indentation.
-			++indentation;
-		}
-	}
+    // Move start to beginning of line.
+    while (start > 0 && content.at(start - 1) != QLatin1Char('\n')) {
+        --start;
+        if (!content.at(start).isSpace()) {
+            return; // Not standalone.
+        } else if (content.at(start).category() == QChar::Separator_Space) {
+            // If its an actual "white space" and not a new line, it counts toward indentation.
+            ++indentation;
+        }
+    }
 
-	// Move end to one past end of line.
-	while (end <= content.size() && content.at(end - 1) != QLatin1Char('\n')) {
-		if (end < content.size() && !content.at(end).isSpace()) {
-			return; // Not standalone.
-		}
-		++end;
-	}
+    // Move end to one past end of line.
+    while (end <= content.size() && content.at(end - 1) != QLatin1Char('\n')) {
+        if (end < content.size() && !content.at(end).isSpace()) {
+            return; // Not standalone.
+        }
+        ++end;
+    }
 
-	tag.start = start;
-	tag.end = end;
-	tag.indentation = indentation;
+    tag.start = start;
+    tag.end = end;
+    tag.indentation = indentation;
 }

--- a/src/mustache.cpp
+++ b/src/mustache.cpp
@@ -17,7 +17,6 @@
 #include <QtCore/QDebug>
 #include <QtCore/QFile>
 #include <QtCore/QStringList>
-#include <QtCore/QTextStream>
 
 using namespace Qt::StringLiterals;
 
@@ -32,24 +31,38 @@ QString Mustache::renderTemplate(const QString &templateString, const QVariantHa
 
 QString Mustache::escapeHtml(const QString &input)
 {
-    QString escaped(input);
-    for (int i = 0; i < escaped.length();) {
-        std::u16string_view replacement;
-        ushort ch = escaped.at(i).unicode();
-        if (ch == u'&') {
-            replacement = u"&amp;";
-        } else if (ch == u'<') {
-            replacement = u"&lt;";
-        } else if (ch == u'>') {
-            replacement = u"&gt;";
-        } else if (ch == u'"') {
-            replacement = u"&quot;";
+    QString escaped;
+    escaped.reserve(input.size() + input.size() / 8);
+    int pos = 0;
+    const int len = input.size();
+    while (pos < len) {
+        const int start = pos;
+        while (pos < len) {
+            const char16_t ch = input.at(pos).unicode();
+            if (ch == u'&' || ch == u'<' || ch == u'>' || ch == u'"') {
+                break;
+            }
+            ++pos;
         }
-        if (!replacement.empty()) {
-            escaped.replace(i, 1, QString::fromUtf16(replacement.data(), replacement.size()));
-            i += replacement.size();
-        } else {
-            ++i;
+        if (pos > start) {
+            escaped += QStringView(input).mid(start, pos - start);
+        }
+        if (pos < len) {
+            switch (input.at(pos).unicode()) {
+            case u'&':
+                escaped += u"&amp;"_s;
+                break;
+            case u'<':
+                escaped += u"&lt;"_s;
+                break;
+            case u'>':
+                escaped += u"&gt;"_s;
+                break;
+            case u'"':
+                escaped += u"&quot;"_s;
+                break;
+            }
+            ++pos;
         }
     }
     return escaped;
@@ -58,10 +71,10 @@ QString Mustache::escapeHtml(const QString &input)
 QString Mustache::unescapeHtml(const QString &escaped)
 {
     QString unescaped(escaped);
-    unescaped.replace(QLatin1String("&lt;"), QLatin1String("<"));
-    unescaped.replace(QLatin1String("&gt;"), QLatin1String(">"));
-    unescaped.replace(QLatin1String("&quot;"), QLatin1String("\""));
-    unescaped.replace(QLatin1String("&amp;"), QLatin1String("&"));
+    unescaped.replace(u"&lt;"_s, u"<"_s);
+    unescaped.replace(u"&gt;"_s, u">"_s);
+    unescaped.replace(u"&quot;"_s, u"\""_s);
+    unescaped.replace(u"&amp;"_s, u"&"_s);
     return unescaped;
 }
 
@@ -228,11 +241,10 @@ PartialFileLoader::PartialFileLoader(const QString &basePath)
 QString PartialFileLoader::getPartial(const QString &name)
 {
     if (!m_cache.contains(name)) {
-        QString path = m_basePath + u'/' + name + u".mustache"_s;
+        const QString path = m_basePath + u'/' + name + u".mustache"_s;
         QFile file(path);
         if (file.open(QIODevice::ReadOnly)) {
-            QTextStream stream(&file);
-            m_cache.insert(name, stream.readAll());
+            m_cache.insert(name, QString::fromUtf8(file.readAll()));
         }
     }
     return m_cache.value(name);
@@ -275,15 +287,17 @@ QString Renderer::render(const QString &_template, Context *context)
 QString Renderer::render(const QString &_template, int startPos, int endPos, Context *context)
 {
     QString output;
+    output.reserve(endPos - startPos);
+    const QStringView templateView(_template);
     int lastTagEnd = startPos;
 
     while (m_errorPos == -1) {
         Tag tag = findTag(_template, lastTagEnd, endPos);
         if (tag.type == Tag::Null) {
-            output += QStringView(_template).mid(lastTagEnd, endPos - lastTagEnd);
+            output += templateView.mid(lastTagEnd, endPos - lastTagEnd);
             break;
         }
-        output += QStringView(_template).mid(lastTagEnd, tag.start - lastTagEnd);
+        output += templateView.mid(lastTagEnd, tag.start - lastTagEnd);
         switch (tag.type) {
         case Tag::Value: {
             QString value = context->stringValue(tag.key);
@@ -423,31 +437,31 @@ Tag Renderer::findTag(const QString &content, int pos, int endPos)
 
     QChar typeChar = content.at(pos);
 
-    if (typeChar == '#') {
+    if (typeChar == u'#') {
         tag.type = Tag::SectionStart;
         tag.key = readTagName(content, pos + 1, endPos);
-    } else if (typeChar == '^') {
+    } else if (typeChar == u'^') {
         tag.type = Tag::InvertedSectionStart;
         tag.key = readTagName(content, pos + 1, endPos);
-    } else if (typeChar == '/') {
+    } else if (typeChar == u'/') {
         tag.type = Tag::SectionEnd;
         tag.key = readTagName(content, pos + 1, endPos);
-    } else if (typeChar == '!') {
+    } else if (typeChar == u'!') {
         tag.type = Tag::Comment;
-    } else if (typeChar == '>') {
+    } else if (typeChar == u'>') {
         tag.type = Tag::Partial;
         tag.key = readTagName(content, pos + 1, endPos);
-    } else if (typeChar == '=') {
+    } else if (typeChar == u'=') {
         tag.type = Tag::SetDelimiter;
         readSetDelimiter(content, pos + 1, tagEndPos - m_tagEndMarker.length());
     } else {
-        if (typeChar == '&') {
+        if (typeChar == u'&') {
             tag.escapeMode = Tag::Unescape;
             ++pos;
-        } else if (typeChar == '{') {
+        } else if (typeChar == u'{') {
             tag.escapeMode = Tag::Raw;
             ++pos;
-            int endTache = content.indexOf('}', pos);
+            int endTache = content.indexOf(u'}', pos);
             if (endTache == tag.end - m_tagEndMarker.length()) {
                 ++tag.end;
             } else {
@@ -467,48 +481,45 @@ Tag Renderer::findTag(const QString &content, int pos, int endPos)
 
 QString Renderer::readTagName(const QString &content, int pos, int endPos)
 {
-    QString name;
-    name.reserve(endPos - pos);
-    while (content.at(pos).isSpace()) {
+    while (pos < endPos && content.at(pos).isSpace()) {
         ++pos;
     }
-    while (!content.at(pos).isSpace() && pos < endPos) {
-        name += content.at(pos);
+    const int start = pos;
+    while (pos < endPos && !content.at(pos).isSpace()) {
         ++pos;
     }
-    return name;
+    return content.mid(start, pos - start);
 }
 
 void Renderer::readSetDelimiter(const QString &content, int pos, int endPos)
 {
-    QString startMarker;
-    QString endMarker;
-
-    while (content.at(pos).isSpace() && pos < endPos) {
+    while (pos < endPos && content.at(pos).isSpace()) {
         ++pos;
     }
 
-    while (!content.at(pos).isSpace() && pos < endPos) {
-        if (content.at(pos) == '=') {
+    int start = pos;
+    while (pos < endPos && !content.at(pos).isSpace()) {
+        if (content.at(pos) == u'=') {
             setError(u"Custom delimiters may not contain '='."_s, pos);
             return;
         }
-        startMarker += content.at(pos);
+        ++pos;
+    }
+    const QString startMarker = content.mid(start, pos - start);
+
+    while (pos < endPos && content.at(pos).isSpace()) {
         ++pos;
     }
 
-    while (content.at(pos).isSpace() && pos < endPos) {
-        ++pos;
-    }
-
-    while (!content.at(pos).isSpace() && pos < endPos - 1) {
-        if (content.at(pos) == '=') {
+    start = pos;
+    while (pos < endPos - 1 && !content.at(pos).isSpace()) {
+        if (content.at(pos) == u'=') {
             setError(u"Custom delimiters may not contain '='."_s, pos);
             return;
         }
-        endMarker += content.at(pos);
         ++pos;
     }
+    const QString endMarker = content.mid(start, pos - start);
 
     m_tagStartMarker = startMarker;
     m_tagEndMarker = endMarker;
@@ -554,7 +565,7 @@ void Renderer::expandTag(Tag &tag, const QString &content)
     int indentation = 0;
 
     // Move start to beginning of line.
-    while (start > 0 && content.at(start - 1) != QLatin1Char('\n')) {
+    while (start > 0 && content.at(start - 1) != u'\n') {
         --start;
         if (!content.at(start).isSpace()) {
             return; // Not standalone.
@@ -565,7 +576,7 @@ void Renderer::expandTag(Tag &tag, const QString &content)
     }
 
     // Move end to one past end of line.
-    while (end <= content.size() && content.at(end - 1) != QLatin1Char('\n')) {
+    while (end <= content.size() && content.at(end - 1) != u'\n') {
         if (end < content.size() && !content.at(end).isSpace()) {
             return; // Not standalone.
         }

--- a/src/mustache.h
+++ b/src/mustache.h
@@ -4,12 +4,12 @@
   Redistribution and use in source and binary forms, with or without modification,
   are permitted provided that the following conditions are met:
 
-    Redistributions of source code must retain the above copyright notice,
-    this list of conditions and the following disclaimer.
+  Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
 
-    Redistributions in binary form must reproduce the above copyright notice,
-    this list of conditions and the following disclaimer in the documentation
-    and/or other materials provided with the distribution.
+  Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
 */
 
 #pragma once
@@ -17,134 +17,122 @@
 #include <QtCore/QStack>
 #include <QtCore/QString>
 #include <QtCore/QVariant>
+#include <functional>
 
-#if __cplusplus >= 201103L
-#include <functional> /* for std::function */
-#endif
-
-namespace Mustache
-{
+namespace Mustache {
 
 class PartialResolver;
 class Renderer;
 
 /** Context is an interface that Mustache::Renderer::render() uses to
-  * fetch substitutions for template tags.
-  */
+ * fetch substitutions for template tags.
+ */
 class Context
 {
 public:
-	/** Create a context.  @p resolver is used to fetch the expansions for any {{>partial}} tags
-	  * which appear in a template.
-	  */
-	explicit Context(PartialResolver* resolver = 0);
-	virtual ~Context() {}
+    /** Create a context.  @p resolver is used to fetch the expansions for any {{>partial}} tags
+     * which appear in a template.
+     */
+    explicit Context(PartialResolver *resolver = nullptr);
+    virtual ~Context() = default;
 
-	/** Returns a string representation of the value for @p key in the current context.
-	  * This is used to replace a Mustache value tag.
-	  */
-	virtual QString stringValue(const QString& key) const = 0;
+    /** Returns a string representation of the value for @p key in the current context.
+     * This is used to replace a Mustache value tag.
+     */
+    virtual QString stringValue(const QString &key) const = 0;
 
-	/** Returns true if the value for @p key is 'false' or an empty list.
-	  * 'False' values typically include empty strings, the boolean value false etc.
-	  *
-	  * When processing a section Mustache tag, the section is not rendered if the key
-	  * is false, or for an inverted section tag, the section is only rendered if the key
-	  * is false.
-	  */
-	virtual bool isFalse(const QString& key) const = 0;
+    /** Returns true if the value for @p key is 'false' or an empty list.
+     * 'False' values typically include empty strings, the boolean value false etc.
+     * When processing a section Mustache tag, the section is not rendered if the key
+     * is false, or for an inverted section tag, the section is only rendered if the key
+     * is false.
+     */
+    virtual bool isFalse(const QString &key) const = 0;
 
-	/** Returns the number of items in the list value for @p key or 0 if
-	  * the value for @p key is not a list.
-	  */
-	virtual int listCount(const QString& key) const = 0;
+    /** Returns the number of items in the list value for @p key or 0 if
+     * the value for @p key is not a list.
+     */
+    virtual int listCount(const QString &key) const = 0;
 
-	/** Set the current context to the value for @p key.
-	  * If index is >= 0, set the current context to the @p index'th value
-	  * in the list value for @p key.
-	  */
-	virtual void push(const QString& key, int index = -1) = 0;
+    /** Set the current context to the value for @p key.
+     * If index is >= 0, set the current context to the @p index'th value
+     * in the list value for @p key.
+     */
+    virtual void push(const QString &key, int index = -1) = 0;
 
-	/** Exit the current context. */
-	virtual void pop() = 0;
+    /** Exit the current context. */
+    virtual void pop() = 0;
 
-	/** Returns the partial template for a given @p key. */
-	QString partialValue(const QString& key) const;
+    /** Returns the partial template for a given @p key. */
+    QString partialValue(const QString &key) const;
 
-	/** Returns the partial resolver passed to the constructor. */
-	PartialResolver* partialResolver() const;
+    /** Returns the partial resolver passed to the constructor. */
+    PartialResolver *partialResolver() const;
 
-	/** Returns true if eval() should be used to render section tags using @p key.
-	 * If canEval() returns true for a key, the renderer will pass the literal, unrendered
-	 * block of text for the section to eval() and replace the section with the result.
-	 *
-	 * canEval() and eval() are equivalents for callable objects (eg. lambdas) in other
-	 * Mustache implementations.
-	 *
-	 * The default implementation always returns false.
-	 */
-	virtual bool canEval(const QString& key) const;
+    /** Returns true if eval() should be used to render section tags using @p key.
+     * If canEval() returns true for a key, the renderer will pass the literal, unrendered
+     * block of text for the section to eval() and replace the section with the result.
+     * canEval() and eval() are equivalents for callable objects (eg. lambdas) in other
+     * Mustache implementations.
+     * The default implementation always returns false.
+     */
+    virtual bool canEval(const QString &key) const;
 
-	/** Callback used to render a template section with the given @p key.
-	 * @p renderer will substitute the original section tag with the result of eval().
-	 *
-	 * The default implementation returns an empty string.
-	 */
-	virtual QString eval(const QString& key, const QString& _template, Renderer* renderer);
+    /** Callback used to render a template section with the given @p key.
+     * @p renderer will substitute the original section tag with the result of eval().
+     * The default implementation returns an empty string.
+     */
+    virtual QString eval(const QString &key, const QString &_template, Renderer *renderer);
 
 private:
-	PartialResolver* m_partialResolver;
+    PartialResolver *m_partialResolver;
 };
 
 /** A context implementation which wraps a QVariantHash or QVariantMap. */
 class QtVariantContext : public Context
 {
 public:
-	/** Construct a QtVariantContext which wraps a dictionary in a QVariantHash
-	 * or a QVariantMap.
-	 */
-#if __cplusplus >= 201103L
-	typedef std::function<QString(const QString&, Mustache::Renderer*, Mustache::Context*)> fn_t;
-#else
-	typedef QString (*fn_t)(const QString&, Mustache::Renderer*, Mustache::Context*);
-#endif
-	explicit QtVariantContext(const QVariant& root, PartialResolver* resolver = 0);
+    /** Construct a QtVariantContext which wraps a dictionary in a QVariantHash
+     * or a QVariantMap.
+     */
+    using fn_t = std::function<QString(const QString &, Mustache::Renderer *, Mustache::Context *)>;
+    explicit QtVariantContext(const QVariant &root, PartialResolver *resolver = nullptr);
 
-	virtual QString stringValue(const QString& key) const;
-	virtual bool isFalse(const QString& key) const;
-	virtual int listCount(const QString& key) const;
-	virtual void push(const QString& key, int index = -1);
-	virtual void pop();
-	virtual bool canEval(const QString& key) const;
-	virtual QString eval(const QString& key, const QString& _template, Mustache::Renderer* renderer);
+    QString stringValue(const QString &key) const override;
+    bool isFalse(const QString &key) const override;
+    int listCount(const QString &key) const override;
+    void push(const QString &key, int index = -1) override;
+    void pop() override;
+    bool canEval(const QString &key) const override;
+    QString eval(const QString &key, const QString &_template, Mustache::Renderer *renderer) override;
 
 private:
-	QVariant value(const QString& key) const;
+    QVariant value(const QString &key) const;
 
-	QStack<QVariant> m_contextStack;
+    QStack<QVariant> m_contextStack;
 };
 
 /** Interface for fetching template partials. */
 class PartialResolver
 {
 public:
-	virtual ~PartialResolver() {}
+    virtual ~PartialResolver() = default;
 
-	/** Returns the partial template with a given @p name. */
-	virtual QString getPartial(const QString& name) = 0;
+    /** Returns the partial template with a given @p name. */
+    virtual QString getPartial(const QString &name) = 0;
 };
 
 /** A simple partial fetcher which returns templates from a map of (partial name -> template)
-  */
+ */
 class PartialMap : public PartialResolver
 {
 public:
-	explicit PartialMap(const QHash<QString,QString>& partials);
+    explicit PartialMap(const QHash<QString, QString> &partials);
 
-	virtual QString getPartial(const QString& name);
+    QString getPartial(const QString &name) override;
 
 private:
-	QHash<QString, QString> m_partials;
+    QHash<QString, QString> m_partials;
 };
 
 /** A partial fetcher when loads templates from '<name>.mustache' files
@@ -155,124 +143,110 @@ private:
 class PartialFileLoader : public PartialResolver
 {
 public:
-	explicit PartialFileLoader(const QString& basePath);
+    explicit PartialFileLoader(const QString &basePath);
 
-	virtual QString getPartial(const QString& name);
+    QString getPartial(const QString &name) override;
 
 private:
-	QString m_basePath;
-	QHash<QString, QString> m_cache;
+    QString m_basePath;
+    QHash<QString, QString> m_cache;
 };
 
 /** Holds properties of a tag in a mustache template. */
 struct Tag
 {
-	enum Type
-	{
-		Null,
-		Value, /// A {{key}} or {{{key}}} tag
-		SectionStart, /// A {{#section}} tag
-		InvertedSectionStart, /// An {{^inverted-section}} tag
-		SectionEnd, /// A {{/section}} tag
-		Partial, /// A {{^partial}} tag
-		Comment, /// A {{! comment }} tag
-		SetDelimiter /// A {{=<% %>=}} tag
-	};
+    enum Type {
+        Null,
+        Value,                /// A {{key}} or {{{key}}} tag
+        SectionStart,         /// A {{#section}} tag
+        InvertedSectionStart, /// An {{^inverted-section}} tag
+        SectionEnd,           /// A {{/section}} tag
+        Partial,              /// A {{^partial}} tag
+        Comment,              /// A {{! comment }} tag
+        SetDelimiter          /// A {{=<% %>=}} tag
+    };
 
-	enum EscapeMode
-	{
-		Escape,
-		Unescape,
-		Raw
-	};
+    enum EscapeMode { Escape, Unescape, Raw };
 
-	Tag()
-		: type(Null)
-		, start(0)
-		, end(0)
-		, escapeMode(Escape)
-		, indentation(0)
-	{}
+    Tag() = default;
 
-	Type type;
-	QString key;
-	int start;
-	int end;
-	EscapeMode escapeMode;
-	int indentation;
+    Type type{Null};
+    QString key;
+    int start{0};
+    int end{0};
+    EscapeMode escapeMode{Escape};
+    int indentation{0};
 };
 
 /** Renders Mustache templates, replacing mustache tags with
-  * values from a provided context.
-  */
+ * values from a provided context.
+ */
 class Renderer
 {
 public:
-	Renderer();
+    Renderer();
 
-	/** Render a Mustache template, using @p context to fetch
-	  * the values used to replace Mustache tags.
-	  */
-	QString render(const QString& _template, Context* context);
+    /** Render a Mustache template, using @p context to fetch
+     * the values used to replace Mustache tags.
+     */
+    QString render(const QString &_template, Context *context);
 
-	/** Returns a message describing the last error encountered by the previous
-	  * render() call.
-	  */
-	QString error() const;
+    /** Returns a message describing the last error encountered by the previous
+     * render() call.
+     */
+    QString error() const;
 
-	/** Returns the position in the template where the last error occurred
-	  * when rendering the template or -1 if no error occurred.
-	  *
-	  * If the error occurred in a partial template, the returned position is the offset
-	  * in the partial template.
-	  */
-	int errorPos() const;
+    /** Returns the position in the template where the last error occurred
+     * when rendering the template or -1 if no error occurred.
+     * If the error occurred in a partial template, the returned position is the offset
+     * in the partial template.
+     */
+    int errorPos() const;
 
-	/** Returns the name of the partial where the error occurred, or an empty string
-	 * if the error occurred in the main template.
-	 */
-	QString errorPartial() const;
+    /** Returns the name of the partial where the error occurred, or an empty string
+     * if the error occurred in the main template.
+     */
+    QString errorPartial() const;
 
-	/** Sets the default tag start and end markers.
-	  * This can be overridden within a template.
-	  */
-	void setTagMarkers(const QString& startMarker, const QString& endMarker);
+    /** Sets the default tag start and end markers.
+     * This can be overridden within a template.
+     */
+    void setTagMarkers(const QString &startMarker, const QString &endMarker);
 
 private:
-	QString render(const QString& _template, int startPos, int endPos, Context* context);
+    QString render(const QString &_template, int startPos, int endPos, Context *context);
 
-	Tag findTag(const QString& content, int pos, int endPos);
-	Tag findEndTag(const QString& content, const Tag& startTag, int endPos);
-	void setError(const QString& error, int pos);
+    Tag findTag(const QString &content, int pos, int endPos);
+    Tag findEndTag(const QString &content, const Tag &startTag, int endPos);
+    void setError(const QString &error, int pos);
 
-	void readSetDelimiter(const QString& content, int pos, int endPos);
-	static QString readTagName(const QString& content, int pos, int endPos);
+    void readSetDelimiter(const QString &content, int pos, int endPos);
+    static QString readTagName(const QString &content, int pos, int endPos);
 
-	/** Expands @p tag to fill the line, but only if it is standalone.
-	 *
-	 * The start position is moved to the beginning of the line. The end position is
-	 * moved to one past the end of the line. If @p tag is not standalone, it is
-	 * left unmodified.
-	 *
-	 * A tag is standalone if it is the only non-whitespace token on the the line.
-	 */
-	static void expandTag(Tag& tag, const QString& content);
+    /** Expands @p tag to fill the line, but only if it is standalone.
+     * The start position is moved to the beginning of the line. The end position is
+     * moved to one past the end of the line. If @p tag is not standalone, it is
+     * left unmodified.
+     * A tag is standalone if it is the only non-whitespace token on the the line.
+     */
+    static void expandTag(Tag &tag, const QString &content);
 
-	QStack<QString> m_partialStack;
-	QString m_error;
-	int m_errorPos;
-	QString m_errorPartial;
+    QStack<QString> m_partialStack;
+    QString m_error;
+    int m_errorPos;
+    QString m_errorPartial;
 
-	QString m_tagStartMarker;
-	QString m_tagEndMarker;
+    QString m_tagStartMarker;
+    QString m_tagEndMarker;
 
-	QString m_defaultTagStartMarker;
-	QString m_defaultTagEndMarker;
+    QString m_defaultTagStartMarker;
+    QString m_defaultTagEndMarker;
 };
 
 /** A convenience function which renders a template using the given data. */
-QString renderTemplate(const QString& templateString, const QVariantHash& args);
-
+QString renderTemplate(const QString &templateString, const QVariantHash &args);
+QString escapeHtml(const QString &input);
+QString unescapeHtml(const QString &escaped);
 }
 
 Q_DECLARE_METATYPE(Mustache::QtVariantContext::fn_t)

--- a/src/mustache.h
+++ b/src/mustache.h
@@ -184,7 +184,7 @@ struct Tag
 class Renderer
 {
 public:
-    Renderer();
+    explicit Renderer(Tag::EscapeMode defaultEscapeMode = Tag::Escape);
 
     /** Render a Mustache template, using @p context to fetch
      * the values used to replace Mustache tags.
@@ -241,10 +241,12 @@ private:
 
     QString m_defaultTagStartMarker;
     QString m_defaultTagEndMarker;
+    Tag::EscapeMode m_defaultEscapeMode;
 };
 
 /** A convenience function which renders a template using the given data. */
-[[nodiscard]] QString renderTemplate(const QString &templateString, const QVariantHash &args);
+QString renderTemplate(const QString &templateString, const QVariantHash &args,
+                                     Tag::EscapeMode defaultEscapeMode = Tag::Escape);
 QString escapeHtml(const QString &input);
 QString unescapeHtml(const QString &escaped);
 }

--- a/src/mustache.h
+++ b/src/mustache.h
@@ -244,7 +244,7 @@ private:
 };
 
 /** A convenience function which renders a template using the given data. */
-QString renderTemplate(const QString &templateString, const QVariantHash &args);
+[[nodiscard]] QString renderTemplate(const QString &templateString, const QVariantHash &args);
 QString escapeHtml(const QString &input);
 QString unescapeHtml(const QString &escaped);
 }

--- a/tests/bench_mustache.cpp
+++ b/tests/bench_mustache.cpp
@@ -1,0 +1,239 @@
+/*
+  Benchmarks for qt-mustache performance-critical paths.
+*/
+
+#include "mustache.h"
+
+#include <QHash>
+#include <QString>
+#include <QTest>
+
+using Qt::StringLiterals::operator""_s;
+
+class BenchMustache : public QObject
+{
+	Q_OBJECT
+
+private Q_SLOTS:
+	// ── escapeHtml ──────────────────────────────────────────────
+
+	void escapeHtml_noSpecialChars()
+	{
+		const QString input = u"The quick brown fox jumps over the lazy dog 1234567890"_s;
+		QBENCHMARK {
+			auto result = Mustache::escapeHtml(input);
+			Q_UNUSED(result);
+		}
+	}
+
+	void escapeHtml_fewSpecialChars()
+	{
+		const QString input = u"Hello <b>world</b> & \"friends\""_s;
+		QBENCHMARK {
+			auto result = Mustache::escapeHtml(input);
+			Q_UNUSED(result);
+		}
+	}
+
+	void escapeHtml_manySpecialChars()
+	{
+		const QString input = u"<a href=\"url?x=1&y=2&z=3\"><b>\"bold\" & <i>\"italic\"</i></b></a>"_s;
+		QBENCHMARK {
+			auto result = Mustache::escapeHtml(input);
+			Q_UNUSED(result);
+		}
+	}
+
+	void escapeHtml_largeString()
+	{
+		QString input;
+		input.reserve(10000);
+		for (int i = 0; i < 200; ++i)
+			input += u"Hello <b>world</b> & \"friends\" "_s;
+		QBENCHMARK {
+			auto result = Mustache::escapeHtml(input);
+			Q_UNUSED(result);
+		}
+	}
+
+	// ── unescapeHtml ────────────────────────────────────────────
+
+	void unescapeHtml_noEntities()
+	{
+		const QString input = u"The quick brown fox jumps over the lazy dog 1234567890"_s;
+		QBENCHMARK {
+			auto result = Mustache::unescapeHtml(input);
+			Q_UNUSED(result);
+		}
+	}
+
+	void unescapeHtml_someEntities()
+	{
+		const QString input = u"&lt;b&gt;hello&lt;/b&gt; &amp; &quot;world&quot;"_s;
+		QBENCHMARK {
+			auto result = Mustache::unescapeHtml(input);
+			Q_UNUSED(result);
+		}
+	}
+
+	void unescapeHtml_largeString()
+	{
+		QString input;
+		input.reserve(10000);
+		for (int i = 0; i < 200; ++i)
+			input += u"&lt;b&gt;hello&lt;/b&gt; &amp; wo "_s;
+		QBENCHMARK {
+			auto result = Mustache::unescapeHtml(input);
+			Q_UNUSED(result);
+		}
+	}
+
+	// ── render ──────────────────────────────────────────────────
+
+	void render_simpleSubstitution()
+	{
+		QVariantHash args;
+		args[u"name"_s] = u"John Smith"_s;
+		args[u"age"_s] = 42;
+		args[u"city"_s] = u"Berlin"_s;
+		const QString tmpl = u"Name: {{name}}, Age: {{age}}, City: {{city}}"_s;
+
+		QBENCHMARK {
+			auto result = Mustache::renderTemplate(tmpl, args);
+			Q_UNUSED(result);
+		}
+	}
+
+	void render_htmlEscaping()
+	{
+		QVariantHash args;
+		args[u"html"_s] = u"<script>alert(\"xss\")</script>"_s;
+		const QString tmpl = u"Safe: {{html}}, Raw: {{{html}}}"_s;
+
+		QBENCHMARK {
+			auto result = Mustache::renderTemplate(tmpl, args);
+			Q_UNUSED(result);
+		}
+	}
+
+	void render_listIteration()
+	{
+		QVariantList items;
+		for (int i = 0; i < 100; ++i) {
+			QVariantHash item;
+			item[u"name"_s] = u"Item %1"_s.arg(i);
+			item[u"value"_s] = i * 10;
+			items.append(item);
+		}
+		QVariantHash args;
+		args[u"items"_s] = items;
+		const QString tmpl = u"{{#items}}{{name}}: {{value}}\n{{/items}}"_s;
+
+		QBENCHMARK {
+			auto result = Mustache::renderTemplate(tmpl, args);
+			Q_UNUSED(result);
+		}
+	}
+
+	void render_nestedSections()
+	{
+		QVariantList groups;
+		for (int g = 0; g < 10; ++g) {
+			QVariantList members;
+			for (int m = 0; m < 10; ++m) {
+				QVariantHash member;
+				member[u"name"_s] = u"Person %1-%2"_s.arg(g).arg(m);
+				members.append(member);
+			}
+			QVariantHash group;
+			group[u"title"_s] = u"Group %1"_s.arg(g);
+			group[u"members"_s] = members;
+			groups.append(group);
+		}
+		QVariantHash args;
+		args[u"groups"_s] = groups;
+		const QString tmpl =
+		    u"{{#groups}}== {{title}} ==\n{{#members}}  - {{name}}\n{{/members}}{{/groups}}"_s;
+
+		QBENCHMARK {
+			auto result = Mustache::renderTemplate(tmpl, args);
+			Q_UNUSED(result);
+		}
+	}
+
+	void render_partials()
+	{
+		QVariantList items;
+		for (int i = 0; i < 50; ++i) {
+			QVariantHash item;
+			item[u"label"_s] = u"Entry %1"_s.arg(i);
+			items.append(item);
+		}
+		QVariantHash args;
+		args[u"items"_s] = items;
+
+		QHash<QString, QString> partials;
+		partials[u"row"_s] = u"[{{label}}] "_s;
+
+		const QString tmpl = u"{{#items}}{{>row}}{{/items}}"_s;
+
+		Mustache::Renderer renderer;
+		Mustache::PartialMap partialMap(partials);
+		Mustache::QtVariantContext context(args, &partialMap);
+
+		QBENCHMARK {
+			auto result = renderer.render(tmpl, &context);
+			Q_UNUSED(result);
+		}
+	}
+
+	void render_largeTemplate()
+	{
+		QVariantHash args;
+		for (int i = 0; i < 50; ++i)
+			args[u"key%1"_s.arg(i)] = u"value%1"_s.arg(i);
+
+		QString tmpl;
+		tmpl.reserve(2000);
+		for (int i = 0; i < 50; ++i)
+			tmpl += u"{{key%1}} "_s.arg(i);
+
+		QBENCHMARK {
+			auto result = Mustache::renderTemplate(tmpl, args);
+			Q_UNUSED(result);
+		}
+	}
+
+	void render_invertedSections()
+	{
+		QVariantHash args;
+		args[u"show"_s] = false;
+		args[u"items"_s] = QVariantList{};
+		const QString tmpl =
+		    u"{{^show}}Hidden{{/show}} {{^items}}No items{{/items}}"_s;
+
+		QBENCHMARK {
+			auto result = Mustache::renderTemplate(tmpl, args);
+			Q_UNUSED(result);
+		}
+	}
+
+	void render_dotNotation()
+	{
+		QVariantHash inner;
+		inner[u"city"_s] = u"Berlin"_s;
+		QVariantHash middle;
+		middle[u"location"_s] = inner;
+		QVariantHash args;
+		args[u"person"_s] = middle;
+		const QString tmpl = u"City: {{person.location.city}}"_s;
+
+		QBENCHMARK {
+			auto result = Mustache::renderTemplate(tmpl, args);
+			Q_UNUSED(result);
+		}
+	}
+};
+
+QTEST_GUILESS_MAIN(BenchMustache)
+#include "bench_mustache.moc"

--- a/tests/test_mustache.cpp
+++ b/tests/test_mustache.cpp
@@ -463,6 +463,41 @@ void TestMustache::testQStringListIteration()
 	QCOMPARE(output, u"str1str2str3"_s);
 }
 
+void TestMustache::testDefaultEscapeModeRaw()
+{
+	QVariantHash map;
+	map[u"html"_s] = u"<b>bold</b>"_s;
+	map[u"entity"_s] = u"One &amp; Two"_s;
+
+	// With Raw default, {{key}} should pass through unescaped
+	Mustache::Renderer rawRenderer(Mustache::Tag::Raw);
+	Mustache::QtVariantContext context(map);
+
+	QString output = rawRenderer.render(u"{{html}}"_s, &context);
+	QCOMPARE(output, u"<b>bold</b>"_s);
+
+	// {{{key}}} is still raw
+	output = rawRenderer.render(u"{{{html}}}"_s, &context);
+	QCOMPARE(output, u"<b>bold</b>"_s);
+
+	// {{&key}} still unescapes HTML entities
+	output = rawRenderer.render(u"{{&entity}}"_s, &context);
+	QCOMPARE(output, u"One & Two"_s);
+
+	// Verify default Escape renderer still escapes
+	Mustache::Renderer defaultRenderer;
+	output = defaultRenderer.render(u"{{html}}"_s, &context);
+	QCOMPARE(output, u"&lt;b&gt;bold&lt;/b&gt;"_s);
+
+	// renderTemplate convenience function with Raw
+	output = Mustache::renderTemplate(u"{{html}}"_s, map, Mustache::Tag::Raw);
+	QCOMPARE(output, u"<b>bold</b>"_s);
+
+	// renderTemplate convenience function without explicit mode still escapes
+	output = Mustache::renderTemplate(u"{{html}}"_s, map);
+	QCOMPARE(output, u"&lt;b&gt;bold&lt;/b&gt;"_s);
+}
+
 void TestMustache::testUnescapeHtml()
 {
 	QVariantHash args;

--- a/tests/test_mustache.cpp
+++ b/tests/test_mustache.cpp
@@ -15,38 +15,37 @@
 #include "test_mustache.h"
 
 #include <QDir>
-#include <QList>
 #include <QFile>
 #include <QHash>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QList>
 #include <QString>
 
-#if QT_VERSION >= 0x050000
-    #include <QJsonDocument>
-    #include <QJsonObject>
-    #include <QJsonArray>
-#endif // QT_VERSION >= 0x050000
+using Qt::StringLiterals::operator""_s;
 
 // To be able to use QHash<QString, QString> in QFETCH(..).
-typedef QHash<QString, QString> PartialsHash;
+using PartialsHash = QHash<QString, QString>;
 Q_DECLARE_METATYPE(PartialsHash)
 
 void TestMustache::testValues()
 {
 	QVariantHash map;
-	map["name"] = "John Smith";
-	map["age"] = 42;
-	map["sex"] = "Male";
-	map["company"] = "Smith & Co";
-	map["signature"] = "John Smith of <b>Smith & Co</b>";
-	map["alive"] = false;
+	map[u"name"_s] = u"John Smith"_s;
+	map[u"age"_s] = 42;
+	map[u"sex"_s] = u"Male"_s;
+	map[u"company"_s] = u"Smith & Co"_s;
+	map[u"signature"_s] = u"John Smith of <b>Smith & Co</b>"_s;
+	map[u"alive"_s] = false;
 
-	QString _template = "Name: {{name}}, Age: {{age}}, Sex: {{sex}}, Alive: {{alive}}\n"
-	                    "Company: {{company}}\n"
-	                    "  {{{signature}}}"
-	                    "{{missing-key}}";
-	QString expectedOutput = "Name: John Smith, Age: 42, Sex: Male, Alive: false\n"
-	                         "Company: Smith &amp; Co\n"
-	                         "  John Smith of <b>Smith & Co</b>";
+	QString _template = u"Name: {{name}}, Age: {{age}}, Sex: {{sex}}, Alive: {{alive}}\n"_s
+	                    u"Company: {{company}}\n"_s
+	                    u"  {{{signature}}}"_s
+	                    u"{{missing-key}}"_s;
+	QString expectedOutput = u"Name: John Smith, Age: 42, Sex: Male, Alive: false\n"_s
+	                         u"Company: Smith &amp; Co\n"_s
+	                         u"  John Smith of <b>Smith & Co</b>"_s;
 
 	Mustache::Renderer renderer;
 	Mustache::QtVariantContext context(map);
@@ -61,9 +60,9 @@ void TestMustache::testFloatValues()
 
   for (auto value : values) {
     QVariantHash map;
-    map["val"] = value;
-    QString _template = "Value: {{val}}";
-    QString expectedOutput = "Value: " + QString::number(value);
+    map[u"val"_s] = value;
+    QString _template = u"Value: {{val}}"_s;
+    QString expectedOutput = u"Value: "_s + QString::number(value);
 
     Mustache::Renderer renderer;
     Mustache::QtVariantContext context(map);
@@ -76,26 +75,26 @@ void TestMustache::testFloatValues()
 QVariantHash contactInfo(const QString& name, const QString& email)
 {
 	QVariantHash map;
-	map["name"] = name;
-	map["email"] = email;
+	map[u"name"_s] = name;
+	map[u"email"_s] = email;
 	return map;
 }
 
 void TestMustache::testSections()
 {
-	QVariantHash map = contactInfo("John Smith", "john.smith@gmail.com");
+	QVariantHash map = contactInfo(u"John Smith"_s, u"john.smith@gmail.com"_s);
 	QVariantList contacts;
-	contacts << contactInfo("James Dee", "james@dee.org");
-	contacts << contactInfo("Jim Jones", "jim-jones@yahoo.com");
-	map["contacts"] = contacts;
+	contacts << contactInfo(u"James Dee"_s, u"james@dee.org"_s);
+	contacts << contactInfo(u"Jim Jones"_s, u"jim-jones@yahoo.com"_s);
+	map[u"contacts"_s] = contacts;
 
-	QString _template = "Name: {{name}}, Email: {{email}}\n"
-	                    "{{#contacts}}  {{name}} - {{email}}\n{{/contacts}}"
-	                    "{{^contacts}}  No contacts{{/contacts}}";
+	QString _template = u"Name: {{name}}, Email: {{email}}\n"_s
+	                    u"{{#contacts}}  {{name}} - {{email}}\n{{/contacts}}"_s
+	                    u"{{^contacts}}  No contacts{{/contacts}}"_s;
 
-	QString expectedOutput = "Name: John Smith, Email: john.smith@gmail.com\n"
-	                         "  James Dee - james@dee.org\n"
-	                         "  Jim Jones - jim-jones@yahoo.com\n";
+	QString expectedOutput = u"Name: John Smith, Email: john.smith@gmail.com\n"_s
+	                         u"  James Dee - james@dee.org\n"_s
+	                         u"  Jim Jones - jim-jones@yahoo.com\n"_s;
 
 	Mustache::Renderer renderer;
 	Mustache::QtVariantContext context(map);
@@ -104,16 +103,16 @@ void TestMustache::testSections()
 	QCOMPARE(output, expectedOutput);
 
 	// test inverted sections
-	map.remove("contacts");
+	map.remove(u"contacts"_s);
 	context = Mustache::QtVariantContext(map);
 	output = renderer.render(_template, &context);
 
-	expectedOutput = "Name: John Smith, Email: john.smith@gmail.com\n"
-	                 "  No contacts";
+	expectedOutput = u"Name: John Smith, Email: john.smith@gmail.com\n"_s
+	                 u"  No contacts"_s;
 	QCOMPARE(output, expectedOutput);
 
 	// test with an empty list instead of an empty key
-	map["contacts"] = QVariantHash();
+	map[u"contacts"_s] = QVariantHash();
 	context = Mustache::QtVariantContext(map);
 	output = renderer.render(_template, &context);
 	QCOMPARE(output, expectedOutput);
@@ -122,73 +121,73 @@ void TestMustache::testSections()
 void TestMustache::testSectionQString()
 {
 	QVariantHash data;
-	data["text"] = "test";
-	QString output = Mustache::renderTemplate("{{#text}}{{text}}{{/text}}", data);
-	QCOMPARE(output, QString("test"));
+	data[u"text"_s] = u"test"_s;
+	QString output = Mustache::renderTemplate(u"{{#text}}{{text}}{{/text}}"_s, data);
+	QCOMPARE(output, u"test"_s);
 }
 
 void TestMustache::testFalsiness()
 {
 	Mustache::Renderer renderer;
 	QVariantHash data;
-	QString _template = "{{#bool}}This should not be shown{{/bool}}";
+	QString _template = u"{{#bool}}This should not be shown{{/bool}}"_s;
 
 	// test falsiness of 0
-	data["bool"] = 0;
+	data[u"bool"_s] = 0;
 	Mustache::QtVariantContext context = Mustache::QtVariantContext(data);
 	QString output = renderer.render(_template, &context);
 	QVERIFY2(output.isEmpty(), "0 evaluated as truthy");
 
 	// test falsiness of 0u
-	data["bool"] = 0u;
+	data[u"bool"_s] = 0u;
 	context = Mustache::QtVariantContext(data);
 	output = renderer.render(_template, &context);
 	QVERIFY2(output.isEmpty(), "0u evaluated as truthy");
 
 	// test falsiness of 0ll
-	data["bool"] = 0ll;
+	data[u"bool"_s] = 0ll;
 	context = Mustache::QtVariantContext(data);
 	output = renderer.render(_template, &context);
 	QVERIFY2(output.isEmpty(), "0ll evaluated as truthy");
 
 	// test falsiness of 0ull
-	data["bool"] = 0ull;
+	data[u"bool"_s] = 0ull;
 	context = Mustache::QtVariantContext(data);
 	output = renderer.render(_template, &context);
 	QVERIFY2(output.isEmpty(), "0ull evaluated as truthy");
 
 	// test falsiness of 0.0
-	data["bool"] = 0.0;
+	data[u"bool"_s] = 0.0;
 	context = Mustache::QtVariantContext(data);
 	output = renderer.render(_template, &context);
 	QVERIFY2(output.isEmpty(), "0.0 evaluated as truthy");
 
 	// test falsiness of 0.4
-	data["bool"] = 0.4f;
+	data[u"bool"_s] = 0.4f;
 	context = Mustache::QtVariantContext(data);
 	output = renderer.render(_template, &context);
 	QVERIFY2(!output.isEmpty(), "0.4 evaluated as falsey");
 
 	// test falsiness of 0.5
-	data["bool"] = 0.5f;
+	data[u"bool"_s] = 0.5f;
 	context = Mustache::QtVariantContext(data);
 	output = renderer.render(_template, &context);
 	QVERIFY2(!output.isEmpty(), "0.5f evaluated as falsey");
 
 	// test falsiness of 0.0f
-	data["bool"] = 0.0f;
+	data[u"bool"_s] = 0.0f;
 	context = Mustache::QtVariantContext(data);
 	output = renderer.render(_template, &context);
 	QVERIFY2(output.isEmpty(), "0.0f evaluated as truthy");
 
 	// test falsiness of '\0'
-	data["bool"] = '\0';
+	data[u"bool"_s] = '\0';
 	context = Mustache::QtVariantContext(data);
 	output = renderer.render(_template, &context);
 	QVERIFY2(output.isEmpty(), "'\0' evaluated as truthy");
 
 	// test falsiness of 'false'
-	data["bool"] = false;
+	data[u"bool"_s] = false;
 	context = Mustache::QtVariantContext(data);
 	output = renderer.render(_template, &context);
 	QVERIFY2(output.isEmpty(), "'\0' evaluated as truthy");
@@ -197,47 +196,47 @@ void TestMustache::testFalsiness()
 void TestMustache::testContextLookup()
 {
 	QVariantHash fileMap;
-	fileMap["dir"] = "/home/robert";
-	fileMap["name"] = "robert";
+	fileMap[u"dir"_s] = u"/home/robert"_s;
+	fileMap[u"name"_s] = u"robert"_s;
 
 	QVariantList files;
 	QVariantHash file;
-	file["name"] = "test.pdf";
+	file[u"name"_s] = u"test.pdf"_s;
 	files << file;
 
-	fileMap["files"] = files;
+	fileMap[u"files"_s] = files;
 
-	QString _template = "{{#files}}{{dir}}/{{name}}{{/files}}";
+	QString _template = u"{{#files}}{{dir}}/{{name}}{{/files}}"_s;
 
 	Mustache::Renderer renderer;
 	Mustache::QtVariantContext context(fileMap);
 	QString output = renderer.render(_template, &context);
 
-	QCOMPARE(output, QString("/home/robert/test.pdf"));
+	QCOMPARE(output, u"/home/robert/test.pdf"_s);
 }
 
 void TestMustache::testPartials()
 {
 	QHash<QString, QString> partials;
-	partials["file-info"] = "{{name}} {{size}} {{type}}\n";
+	partials[u"file-info"_s] = u"{{name}} {{size}} {{type}}\n"_s;
 
-	QString _template = "{{#files}}{{>file-info}}{{/files}}";
+	QString _template = u"{{#files}}{{>file-info}}{{/files}}"_s;
 
 	QVariantHash map;
 	QVariantList fileList;
 
 	QVariantHash file1;
-	file1["name"] = "mustache.pdf";
-	file1["size"] = "200KB";
-	file1["type"] = "PDF Document";
+	file1[u"name"_s] = u"mustache.pdf"_s;
+	file1[u"size"_s] = u"200KB"_s;
+	file1[u"type"_s] = u"PDF Document"_s;
 
 	QVariantHash file2;
-	file2["name"] = "cv.doc";
-	file2["size"] = "300KB";
-	file2["type"] = "Microsoft Word Document";
+	file2[u"name"_s] = u"cv.doc"_s;
+	file2[u"size"_s] = u"300KB"_s;
+	file2[u"type"_s] = u"Microsoft Word Document"_s;
 
 	fileList << file1 << file2;
-	map["files"] = fileList;
+	map[u"files"_s] = fileList;
 
 	Mustache::Renderer renderer;
 	Mustache::PartialMap partialMap(partials);
@@ -245,24 +244,24 @@ void TestMustache::testPartials()
 	QString output = renderer.render(_template, &context);
 
 	QCOMPARE(output,
-	         QString("mustache.pdf 200KB PDF Document\n"
-	                 "cv.doc 300KB Microsoft Word Document\n"));
+	         u"mustache.pdf 200KB PDF Document\n"_s
+	         u"cv.doc 300KB Microsoft Word Document\n"_s);
 }
 
 void TestMustache::testSetDelimiters()
 {
 	// test changing the markers within a template
 	QVariantHash map;
-	map["name"] = "John Smith";
-	map["phone"] = "01234 567890";
+	map[u"name"_s] = u"John Smith"_s;
+	map[u"phone"_s] = u"01234 567890"_s;
 
 	QString _template =
-	    "{{=<% %>=}}"
-	    "<%name%>{{ }}<%phone%>"
-	    "<%={{ }}=%>"
-	    " {{name}}<% %>{{phone}}";
+	    u"{{=<% %>=}}"_s
+	    u"<%name%>{{ }}<%phone%>"_s
+	    u"<%={{ }}=%>"_s
+	    u" {{name}}<% %>{{phone}}"_s;
 
-	QString expectedOutput = "John Smith{{ }}01234 567890 John Smith<% %>01234 567890";
+	QString expectedOutput = u"John Smith{{ }}01234 567890 John Smith<% %>01234 567890"_s;
 
 	Mustache::Renderer renderer;
 	Mustache::QtVariantContext context(map);
@@ -271,77 +270,77 @@ void TestMustache::testSetDelimiters()
 	QCOMPARE(output, expectedOutput);
 
 	// test changing the default markers
-	renderer.setTagMarkers("%", "%");
-	output = renderer.render("%name%'s phone number is %phone%", &context);
-	QCOMPARE(output, QString("John Smith's phone number is 01234 567890"));
+	renderer.setTagMarkers(u"%"_s, u"%"_s);
+	output = renderer.render(u"%name%'s phone number is %phone%"_s, &context);
+	QCOMPARE(output, u"John Smith's phone number is 01234 567890"_s);
 
-	renderer.setTagMarkers("{{", "}}");
-	output = renderer.render("{{== ==}}", &context);
-	QCOMPARE(renderer.error(), QString("Custom delimiters may not contain '='."));
+	renderer.setTagMarkers(u"{{"_s, u"}}"_s);
+	output = renderer.render(u"{{== ==}}"_s, &context);
+	QCOMPARE(renderer.error(), u"Custom delimiters may not contain '='."_s);
 }
 
 void TestMustache::testErrors()
 {
 	QVariantHash map;
-	map["name"] = "Jim Jones";
+	map[u"name"_s] = u"Jim Jones"_s;
 
 	QHash<QString, QString> partials;
-	partials["buggy-partial"] = "--{{/one}}--";
+	partials[u"buggy-partial"_s] = u"--{{/one}}--"_s;
 
-	QString _template = "{{name}}";
+	QString _template = u"{{name}}"_s;
 
 	Mustache::Renderer renderer;
 	Mustache::PartialMap partialMap(partials);
 	Mustache::QtVariantContext context(map, &partialMap);
 	QString output = renderer.render(_template, &context);
 
-	QCOMPARE(output, QString("Jim Jones"));
+	QCOMPARE(output, u"Jim Jones"_s);
 	QCOMPARE(renderer.error(), QString());
 	QCOMPARE(renderer.errorPos(), -1);
 
-	_template = "{{#one}} {{/two}}";
+	_template = u"{{#one}} {{/two}}"_s;
 	output = renderer.render(_template, &context);
-	QCOMPARE(renderer.error(), QString("Tag start/end key mismatch"));
+	QCOMPARE(renderer.error(), u"Tag start/end key mismatch"_s);
 	QCOMPARE(renderer.errorPos(), 9);
 	QCOMPARE(renderer.errorPartial(), QString());
 
-	_template = "Hello {{>buggy-partial}}";
+	_template = u"Hello {{>buggy-partial}}"_s;
 	output = renderer.render(_template, &context);
-	QCOMPARE(renderer.error(), QString("Unexpected end tag"));
+	QCOMPARE(renderer.error(), u"Unexpected end tag"_s);
 	QCOMPARE(renderer.errorPos(), 2);
-	QCOMPARE(renderer.errorPartial(), QString("buggy-partial"));
+	QCOMPARE(renderer.errorPartial(), u"buggy-partial"_s);
 }
 
 void TestMustache::testPartialFile()
 {
 	QString path = QCoreApplication::applicationDirPath();
 
-	QVariantHash map = contactInfo("Jim Smith", "jim.smith@gmail.com");
+	QVariantHash map = contactInfo(u"Jim Smith"_s, u"jim.smith@gmail.com"_s);
 
-	QString _template = "{{>partial}}";
+	QString _template = u"{{>partial}}"_s;
 
 	Mustache::Renderer renderer;
 	Mustache::PartialFileLoader partialLoader(path);
 	Mustache::QtVariantContext context(map, &partialLoader);
 	QString output = renderer.render(_template, &context);
 
-	QCOMPARE(output, QString("Jim Smith -- jim.smith@gmail.com\n"));
+	QCOMPARE(output, u"Jim Smith -- jim.smith@gmail.com\n"_s);
 }
 
 void TestMustache::testEscaping()
 {
 	QVariantHash map;
-	map["escape"] = "<b>foo</b>";
-	map["unescape"] = "One &amp; Two &quot;quoted&quot;";
-	map["raw"] = "<b>foo</b>";
+	map[u"escape"_s] = u"<b>foo</b>"_s;
+	map[u"unescape"_s] = u"One &amp; Two &quot;quoted&quot;"_s;
+	map[u"raw"_s] = u"<b>foo</b>"_s;
 
-	QString _template = "{{escape}} {{&unescape}} {{{raw}}}";
+	QString _template = u"{{escape}} {{&unescape}} {{{raw}}}"_s;
 
 	Mustache::Renderer renderer;
 	Mustache::QtVariantContext context(map);
 	QString output = renderer.render(_template, &context);
 
-	QCOMPARE(output, QString("&lt;b&gt;foo&lt;/b&gt; One & Two \"quoted\" <b>foo</b>"));
+	QCOMPARE(output, u"&lt;b&gt;foo&lt;/b&gt; One & Two \"quoted\" <b>foo</b>"_s);
 }
 
 class CounterContext : public Mustache::QtVariantContext
@@ -354,19 +353,19 @@ public:
 		, counter(0)
 	{}
 
-	virtual bool canEval(const QString& key) const {
-		return key == "counter";
+	bool canEval(const QString& key) const override {
+		return key == u"counter"_s;
 	}
 
-	virtual QString eval(const QString& key, const QString& _template, Mustache::Renderer* renderer) {
-		if (key == "counter") {
+	QString eval(const QString& key, const QString& _template, Mustache::Renderer* renderer) override {
+		if (key == u"counter"_s) {
 			++counter;
 		}
 		return renderer->render(_template, this);
 	}
 
-	virtual QString stringValue(const QString& key) const {
-		if (key == "count") {
+	QString stringValue(const QString& key) const override {
+		if (key == u"count"_s) {
 			return QString::number(counter);
 		} else {
 			return Mustache::QtVariantContext::stringValue(key);
@@ -378,101 +377,99 @@ void TestMustache::testEval()
 {
 	QVariantHash map;
 	QVariantList list;
-	list << contactInfo("Rob Knight", "robertknight@gmail.com");
-	list << contactInfo("Jim Smith", "jim.smith@smith.org");
-	map["list"] = list;
+	list << contactInfo(u"Rob Knight"_s, u"robertknight@gmail.com"_s);
+	list << contactInfo(u"Jim Smith"_s, u"jim.smith@smith.org"_s);
+	map[u"list"_s] = list;
 
-	QString _template = "{{#list}}{{#counter}}#{{count}} {{name}} {{email}}{{/counter}}\n{{/list}}";
+	QString _template = u"{{#list}}{{#counter}}#{{count}} {{name}} {{email}}{{/counter}}\n{{/list}}"_s;
 
 	Mustache::Renderer renderer;
 	CounterContext context(map);
 	QString output = renderer.render(_template, &context);
-	QCOMPARE(output, QString("#1 Rob Knight robertknight@gmail.com\n"
-	                         "#2 Jim Smith jim.smith@smith.org\n"));
+	QCOMPARE(output, u"#1 Rob Knight robertknight@gmail.com\n"_s
+	                 u"#2 Jim Smith jim.smith@smith.org\n"_s);
 }
 
 void TestMustache::testHelpers()
 {
 	QVariantHash args;
-	args.insert("name", "Jim Smith");
-	args.insert("age", 42);
+	args.insert(u"name"_s, u"Jim Smith"_s);
+	args.insert(u"age"_s, 42);
 
-	QString output = Mustache::renderTemplate("Hello {{name}}, you are {{age}}", args);
-	QCOMPARE(output, QString("Hello Jim Smith, you are 42"));
+	QString output = Mustache::renderTemplate(u"Hello {{name}}, you are {{age}}"_s, args);
+	QCOMPARE(output, u"Hello Jim Smith, you are 42"_s);
 }
 
 void TestMustache::testIncompleteTag()
 {
 	QVariantHash args;
-	args.insert("name", "Jim Smith");
+	args.insert(u"name"_s, u"Jim Smith"_s);
 
-	QString output = Mustache::renderTemplate("Hello {{name}}, you are {", args);
-	QCOMPARE(output, QString("Hello Jim Smith, you are {"));
+	QString output = Mustache::renderTemplate(u"Hello {{name}}, you are {"_s, args);
+	QCOMPARE(output, u"Hello Jim Smith, you are {"_s);
 
-	output = Mustache::renderTemplate("Hello {{name}}, you are {{", args);
-	QCOMPARE(output, QString("Hello Jim Smith, you are {{"));
+	output = Mustache::renderTemplate(u"Hello {{name}}, you are {{"_s, args);
+	QCOMPARE(output, u"Hello Jim Smith, you are {{"_s);
 
-	output = Mustache::renderTemplate("Hello {{name}}, you are {{}", args);
-	QCOMPARE(output, QString("Hello Jim Smith, you are {{}"));
+	output = Mustache::renderTemplate(u"Hello {{name}}, you are {{}"_s, args);
+	QCOMPARE(output, u"Hello Jim Smith, you are {{}"_s);
 }
 
 void TestMustache::testIncompleteSection()
 {
 	QVariantHash args;
-	args.insert("list", QVariantList() << QVariantHash());
+	args.insert(u"list"_s, QVariantList() << QVariantHash());
 
 	Mustache::Renderer renderer;
 	Mustache::QtVariantContext context(args);
-	QString output = renderer.render("{{#list}}", &context);
+	QString output = renderer.render(u"{{#list}}"_s, &context);
 	QCOMPARE(output, QString());
-	QCOMPARE(renderer.error(), QString("No matching end tag found for section"));
+	QCOMPARE(renderer.error(), u"No matching end tag found for section"_s);
 
-	output = renderer.render("{{^list}}", &context);
+	output = renderer.render(u"{{^list}}"_s, &context);
 	QCOMPARE(output, QString());
-	QCOMPARE(renderer.error(), QString("No matching end tag found for inverted section"));
+	QCOMPARE(renderer.error(), u"No matching end tag found for inverted section"_s);
 
-	output = renderer.render("{{/list}}", &context);
+	output = renderer.render(u"{{/list}}"_s, &context);
 	QCOMPARE(output, QString());
-	QCOMPARE(renderer.error(), QString("Unexpected end tag"));
+	QCOMPARE(renderer.error(), u"Unexpected end tag"_s);
 
-	output = renderer.render("{{#list}}{{/foo}}", &context);
+	output = renderer.render(u"{{#list}}{{/foo}}"_s, &context);
 	QCOMPARE(output, QString());
-	QCOMPARE(renderer.error(), QString("Tag start/end key mismatch"));
+	QCOMPARE(renderer.error(), u"Tag start/end key mismatch"_s);
 }
 
 static QString decorate(const QString& text, Mustache::Renderer* r, Mustache::Context* ctx)
 {
-	return "~" + r->render(text, ctx) + "~";
+	return u"~"_s + r->render(text, ctx) + u"~"_s;
 }
 
 void TestMustache::testLambda()
 {
 	QVariantHash args;
-	args["text"] = "test";
-	args["fn"] = QVariant::fromValue(Mustache::QtVariantContext::fn_t(decorate));
-	QString output = Mustache::renderTemplate("{{#fn}}{{text}}{{/fn}}", args);
-	QCOMPARE(output, QString("~test~"));
+	args[u"text"_s] = u"test"_s;
+	args[u"fn"_s] = QVariant::fromValue(Mustache::QtVariantContext::fn_t(decorate));
+	QString output = Mustache::renderTemplate(u"{{#fn}}{{text}}{{/fn}}"_s, args);
+	QCOMPARE(output, u"~test~"_s);
 }
 
 void TestMustache::testQStringListIteration()
 {
 	QStringList list;
-	list << "str1" << "str2" << "str3";
+	list << u"str1"_s << u"str2"_s << u"str3"_s;
 	QVariantHash args;
-	args["list"] = list;
-	QString output = Mustache::renderTemplate("{{#list}}{{.}}{{/list}}", args);
-	QCOMPARE(output, QString("str1str2str3"));
+	args[u"list"_s] = list;
+	QString output = Mustache::renderTemplate(u"{{#list}}{{.}}{{/list}}"_s, args);
+	QCOMPARE(output, u"str1str2str3"_s);
 }
 
 void TestMustache::testUnescapeHtml()
 {
 	QVariantHash args;
-	args["s"] = "&lt;&gt;&amp;&quot;&amp;quot;";
-	QString output = Mustache::renderTemplate("{{&s}}", args);
-	QCOMPARE(output, QString("<>&\"&quot;"));
+	args[u"s"_s] = u"&lt;&gt;&amp;&quot;&amp;quot;"_s;
+	QString output = Mustache::renderTemplate(u"{{&s}}"_s, args);
+	QCOMPARE(output, u"<>&\"&quot;"_s);
 }
-
-#if QT_VERSION >= 0x050000 // JSON classes only in Qt 5+.
 
 void TestMustache::testConformance_data()
 {
@@ -481,27 +478,28 @@ void TestMustache::testConformance_data()
 	QTest::addColumn<QHash<QString, QString> >("partials");
 	QTest::addColumn<QString>("expected");
 
-	QDir specsDir = QDir(".");
+	QDir specsDir = QDir(u"."_s);
 
-	foreach (const QString &fileName, specsDir.entryList(QStringList() << "*.json")) {
+	const auto jsonFiles = specsDir.entryList(QStringList{u"*.json"_s});
+	for (const QString &fileName : jsonFiles) {
 		QFile file(specsDir.filePath(fileName));
-		QVERIFY2(file.open(QIODevice::ReadOnly), qPrintable(fileName + ": " + file.errorString()));
+		QVERIFY2(file.open(QIODevice::ReadOnly), qPrintable(fileName + u": "_s + file.errorString()));
 
 		QJsonDocument document = QJsonDocument::fromJson(file.readAll());
-		QJsonArray testCaseValues = document.object()["tests"].toArray();
+		QJsonArray testCaseValues = document.object()[u"tests"_s].toArray();
 
 		for (const QJsonValue &testCaseValue: testCaseValues) {
 			QJsonObject testCaseObject = testCaseValue.toObject();
 
-			QString name = fileName + " - " + testCaseObject["name"].toString();
-			QVariantMap data = testCaseObject["data"].toObject().toVariantMap();
-			QString template_ = testCaseObject["template"].toString();
-			QJsonObject partialsObject = testCaseObject["partials"].toObject();
+			QString name = fileName + u" - "_s + testCaseObject[u"name"_s].toString();
+			QVariantMap data = testCaseObject[u"data"_s].toObject().toVariantMap();
+			QString template_ = testCaseObject[u"template"_s].toString();
+			QJsonObject partialsObject = testCaseObject[u"partials"_s].toObject();
 			PartialsHash partials;
-			foreach (const QString &partialName, partialsObject.keys()) {
+			for (const QString &partialName : partialsObject.keys()) {
 				partials.insert(partialName, partialsObject[partialName].toString());
 			}
-			QString expected = testCaseObject["expected"].toString();
+			QString expected = testCaseObject[u"expected"_s].toString();
 
 			QTest::newRow(qPrintable(name)) << data << template_ << partials << expected;
 		}
@@ -529,8 +527,6 @@ void TestMustache::testConformance()
 
 	QCOMPARE(output, expected);
 }
-
-#endif // QT_VERSION >= 0x050000
 
 // Create a QCoreApplication for the test.  In Qt 5 this can be
 // done with QTEST_GUILESS_MAIN().

--- a/tests/test_mustache.h
+++ b/tests/test_mustache.h
@@ -41,9 +41,7 @@ private Q_SLOTS:
 	void testLambda();
 	void testQStringListIteration();
 	void testUnescapeHtml();
-#if QT_VERSION >= 0x050000
 	void testConformance();
 	void testConformance_data();
-#endif // QT_VERSION >= 0x050000
 };
 

--- a/tests/test_mustache.h
+++ b/tests/test_mustache.h
@@ -41,6 +41,7 @@ private Q_SLOTS:
 	void testLambda();
 	void testQStringListIteration();
 	void testUnescapeHtml();
+	void testDefaultEscapeModeRaw();
 	void testConformance();
 	void testConformance_data();
 };


### PR DESCRIPTION
The patch set contains:
 - modernize the code by using c++11 goodies (nullptr, std::function, override, etc.), make use of QString literals
 - make the functions faster, especially  [un]escapeHtml which now is much faster, drop the Qt5 support.
 - make the defaultEscapeMode configurable, by default uses Tag::Escape
 - last but not least allow mustache to be used via `FetchContent_Declare` 